### PR TITLE
Mount health bar

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.15.7
 
 
 # Mod Properties
-mod_version=2.3-SNAPSHOT
+mod_version=2.3
 maven_group=com.github.thedeathlycow
 archives_base_name=thermoo
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.15.7
 
 
 # Mod Properties
-mod_version=2.2
+mod_version=2.3-SNAPSHOT
 maven_group=com.github.thedeathlycow
 archives_base_name=thermoo
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/client/StatusBarOverlayRenderEvents.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/client/StatusBarOverlayRenderEvents.java
@@ -32,6 +32,15 @@ public class StatusBarOverlayRenderEvents {
             }
     );
 
+    /**
+     * Invoked after the players mount health is drawn.
+     * <p>
+     * Is not integrated with Colorful Hearts or Overflowing Bars by default, however these mods do not override the mount
+     * health.
+     * <p>
+     * Note that indexes are backwards from the regular health: index 0 is the heart on the far RIGHT of the screen.
+     * Adjust half-hearts accordingly.
+     */
     public static final Event<RenderMountHealthBarCallback> AFTER_MOUNT_HEALTH_BAR = EventFactory.createArrayBacked(
             RenderMountHealthBarCallback.class,
             callbacks -> (context, player, mount, mountHeartPositions, displayMountHealth, maxDisplayMountHealth) -> {
@@ -73,6 +82,15 @@ public class StatusBarOverlayRenderEvents {
     @FunctionalInterface
     public interface RenderMountHealthBarCallback {
 
+        /**
+         * @param context               Draw context
+         * @param player                The main player
+         * @param mount                 The animal the player is riding (ex: pig, horse, camel)
+         * @param mountHeartPositions   The positions of the hearts. Elements may be null, indicating that a heart
+         *                              should not be rendered at this index.
+         * @param displayMountHealth    How many half hearts are to be displayed
+         * @param maxDisplayMountHealth The maximum number of half hearts to be displayed
+         */
         void render(
                 DrawContext context,
                 PlayerEntity player,

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/client/StatusBarOverlayRenderEvents.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/client/StatusBarOverlayRenderEvents.java
@@ -5,6 +5,7 @@ import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import org.joml.Vector2i;
 
@@ -31,6 +32,20 @@ public class StatusBarOverlayRenderEvents {
             }
     );
 
+    public static final Event<RenderMountHealthBarCallback> AFTER_MOUNT_HEALTH_BAR = EventFactory.createArrayBacked(
+            RenderMountHealthBarCallback.class,
+            callbacks -> (context, player, mount, mountHeartPositions, displayMountHealth, maxDisplayMountHealth) -> {
+                for (RenderMountHealthBarCallback callback : callbacks) {
+                    callback.render(
+                            context,
+                            player, mount,
+                            mountHeartPositions,
+                            displayMountHealth, maxDisplayMountHealth
+                    );
+                }
+            }
+    );
+
     @FunctionalInterface
     public interface RenderHealthBarCallback {
 
@@ -51,6 +66,20 @@ public class StatusBarOverlayRenderEvents {
                 Vector2i[] heartPositions,
                 int displayHealth,
                 int maxDisplayHealth
+        );
+
+    }
+
+    @FunctionalInterface
+    public interface RenderMountHealthBarCallback {
+
+        void render(
+                DrawContext context,
+                PlayerEntity player,
+                LivingEntity mount,
+                Vector2i[] mountHeartPositions,
+                int displayMountHealth,
+                int maxDisplayMountHealth
         );
 
     }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/HeartOverlayImpl.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/HeartOverlayImpl.java
@@ -19,7 +19,9 @@ public class HeartOverlayImpl {
     });
 
     public void setHeartPosition(int index, int heartX, int heartY) {
-        heartPositions[index] = new Vector2i(heartX, heartY);
+        if (index < heartPositions.length) {
+            heartPositions[index] = new Vector2i(heartX, heartY);
+        }
     }
 
     public Vector2i[] getHeartPositions() {

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/InGameHudMixin.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/InGameHudMixin.java
@@ -1,0 +1,77 @@
+package com.github.thedeathlycow.thermoo.mixin.client;
+
+import com.github.thedeathlycow.thermoo.api.client.StatusBarOverlayRenderEvents;
+import com.github.thedeathlycow.thermoo.impl.client.HeartOverlayImpl;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+import org.joml.Vector2i;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Arrays;
+
+/**
+ * For the mount health bar. For the player health bar see {@link com.github.thedeathlycow.thermoo.mixin.client.compat.overflowingbars.absent.InGameHudMixin}
+ */
+@Mixin(InGameHud.class)
+public abstract class InGameHudMixin {
+    @Shadow
+    protected abstract LivingEntity getRiddenEntity();
+
+    @Shadow protected abstract PlayerEntity getCameraPlayer();
+
+    @Unique
+    private int scorchful$mountIndex = 0;
+
+    @WrapOperation(
+            method = "renderMountHealth",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V",
+                    ordinal = 0
+            )
+    )
+    private void captureMountHealth(DrawContext instance, Identifier texture, int x, int y, int u, int v, int width, int height, Operation<Void> original) {
+        HeartOverlayImpl.INSTANCE.setHeartPosition(scorchful$mountIndex, x, y);
+        original.call(instance, texture, x, y, u, v, width, height);
+        scorchful$mountIndex++;
+    }
+
+    @Inject(
+            method = "renderMountHealth",
+            at = @At("TAIL")
+    )
+    private void renderMountHealth(DrawContext context, CallbackInfo ci) {
+        Vector2i[] heartPositions = HeartOverlayImpl.INSTANCE.getHeartPositions();
+
+        PlayerEntity player = this.getCameraPlayer();
+        LivingEntity mount = this.getRiddenEntity();
+        float health = mount.getHealth();
+        float maxHealth = mount.getMaxHealth();
+
+        int displayHealth = Math.min(MathHelper.ceil(health), heartPositions.length);
+        int maxDisplayHealth = Math.min(MathHelper.ceil(maxHealth), heartPositions.length);
+
+        StatusBarOverlayRenderEvents.AFTER_MOUNT_HEALTH_BAR.invoker()
+                .render(
+                        context,
+                        player,
+                        mount,
+                        heartPositions,
+                        displayHealth,
+                        maxDisplayHealth
+                );
+        Arrays.fill(HeartOverlayImpl.INSTANCE.getHeartPositions(), null);
+        scorchful$mountIndex = 0;
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/compat/overflowingbars/absent/InGameHudMixin.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/compat/overflowingbars/absent/InGameHudMixin.java
@@ -2,12 +2,18 @@ package com.github.thedeathlycow.thermoo.mixin.client.compat.overflowingbars.abs
 
 import com.github.thedeathlycow.thermoo.api.client.StatusBarOverlayRenderEvents;
 import com.github.thedeathlycow.thermoo.impl.client.HeartOverlayImpl;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 import org.joml.Vector2i;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -16,7 +22,17 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import java.util.Arrays;
 
 @Mixin(InGameHud.class)
-public class InGameHudMixin {
+public abstract class InGameHudMixin {
+
+    @Shadow protected abstract LivingEntity getRiddenEntity();
+
+    @Shadow protected abstract PlayerEntity getCameraPlayer();
+
+    @Unique
+    private int scorchful$mountIndex = 0;
+
+    // player health bar
+
     @Inject(
             method = "renderHealthBar",
             at = @At(
@@ -82,6 +98,49 @@ public class InGameHudMixin {
                         maxDisplayHealth
                 );
         Arrays.fill(HeartOverlayImpl.INSTANCE.getHeartPositions(), null);
+    }
+
+    // mount health bar
+    @WrapOperation(
+            method = "renderMountHealth",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V",
+                    ordinal = 0
+            )
+    )
+    private void captureMountHealth(DrawContext instance, Identifier texture, int x, int y, int u, int v, int width, int height, Operation<Void> original) {
+        HeartOverlayImpl.INSTANCE.setHeartPosition(scorchful$mountIndex, x, y);
+        original.call(instance, texture, x, y, u, v, width, height);
+        scorchful$mountIndex++;
+    }
+
+    @Inject(
+            method = "renderMountHealth",
+            at = @At("TAIL")
+    )
+    private void renderMountHealth(DrawContext context, CallbackInfo ci) {
+        Vector2i[] heartPositions = HeartOverlayImpl.INSTANCE.getHeartPositions();
+
+        PlayerEntity player = this.getCameraPlayer();
+        LivingEntity mount = this.getRiddenEntity();
+        float health = mount.getHealth();
+        float maxHealth = mount.getMaxHealth();
+
+        int displayHealth = Math.min(MathHelper.ceil(health), heartPositions.length);
+        int maxDisplayHealth = Math.min(MathHelper.ceil(maxHealth), heartPositions.length);
+
+        StatusBarOverlayRenderEvents.AFTER_MOUNT_HEALTH_BAR.invoker()
+                .render(
+                        context,
+                        player,
+                        mount,
+                        heartPositions,
+                        displayHealth,
+                        maxDisplayHealth
+                );
+        Arrays.fill(HeartOverlayImpl.INSTANCE.getHeartPositions(), null);
+        scorchful$mountIndex = 0;
     }
 
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/compat/overflowingbars/absent/InGameHudMixin.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/compat/overflowingbars/absent/InGameHudMixin.java
@@ -2,18 +2,12 @@ package com.github.thedeathlycow.thermoo.mixin.client.compat.overflowingbars.abs
 
 import com.github.thedeathlycow.thermoo.api.client.StatusBarOverlayRenderEvents;
 import com.github.thedeathlycow.thermoo.impl.client.HeartOverlayImpl;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 import org.joml.Vector2i;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -23,15 +17,6 @@ import java.util.Arrays;
 
 @Mixin(InGameHud.class)
 public abstract class InGameHudMixin {
-
-    @Shadow protected abstract LivingEntity getRiddenEntity();
-
-    @Shadow protected abstract PlayerEntity getCameraPlayer();
-
-    @Unique
-    private int scorchful$mountIndex = 0;
-
-    // player health bar
 
     @Inject(
             method = "renderHealthBar",
@@ -98,49 +83,6 @@ public abstract class InGameHudMixin {
                         maxDisplayHealth
                 );
         Arrays.fill(HeartOverlayImpl.INSTANCE.getHeartPositions(), null);
-    }
-
-    // mount health bar
-    @WrapOperation(
-            method = "renderMountHealth",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V",
-                    ordinal = 0
-            )
-    )
-    private void captureMountHealth(DrawContext instance, Identifier texture, int x, int y, int u, int v, int width, int height, Operation<Void> original) {
-        HeartOverlayImpl.INSTANCE.setHeartPosition(scorchful$mountIndex, x, y);
-        original.call(instance, texture, x, y, u, v, width, height);
-        scorchful$mountIndex++;
-    }
-
-    @Inject(
-            method = "renderMountHealth",
-            at = @At("TAIL")
-    )
-    private void renderMountHealth(DrawContext context, CallbackInfo ci) {
-        Vector2i[] heartPositions = HeartOverlayImpl.INSTANCE.getHeartPositions();
-
-        PlayerEntity player = this.getCameraPlayer();
-        LivingEntity mount = this.getRiddenEntity();
-        float health = mount.getHealth();
-        float maxHealth = mount.getMaxHealth();
-
-        int displayHealth = Math.min(MathHelper.ceil(health), heartPositions.length);
-        int maxDisplayHealth = Math.min(MathHelper.ceil(maxHealth), heartPositions.length);
-
-        StatusBarOverlayRenderEvents.AFTER_MOUNT_HEALTH_BAR.invoker()
-                .render(
-                        context,
-                        player,
-                        mount,
-                        heartPositions,
-                        displayHealth,
-                        maxDisplayHealth
-                );
-        Arrays.fill(HeartOverlayImpl.INSTANCE.getHeartPositions(), null);
-        scorchful$mountIndex = 0;
     }
 
 }

--- a/src/main/resources/thermoo.client.mixins.json
+++ b/src/main/resources/thermoo.client.mixins.json
@@ -4,6 +4,7 @@
     "compatibilityLevel": "JAVA_17",
     "plugin": "com.github.thedeathlycow.thermoo.mixin.client.compat.Plugin",
     "client": [
+        "InGameHudMixin",
         "compat.colorfulhearts.present.HeartRendererMixin",
         "compat.overflowingbars.absent.InGameHudMixin",
         "compat.overflowingbars.present.HealthBarRendererMixin"

--- a/src/testmod/java/com/github/thedeathlycow/thermoo/testmod/ThermooTestModClient.java
+++ b/src/testmod/java/com/github/thedeathlycow/thermoo/testmod/ThermooTestModClient.java
@@ -4,6 +4,7 @@ import com.github.thedeathlycow.thermoo.api.client.StatusBarOverlayRenderEvents;
 import com.github.thedeathlycow.thermoo.impl.Thermoo;
 import net.fabricmc.api.ClientModInitializer;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
@@ -20,6 +21,18 @@ public class ThermooTestModClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         StatusBarOverlayRenderEvents.AFTER_HEALTH_BAR.register(ThermooTestModClient::renderFireHeartBar);
+        StatusBarOverlayRenderEvents.AFTER_MOUNT_HEALTH_BAR.register(ThermooTestModClient::renderMountFireHeartBar);
+    }
+
+    public static void renderMountFireHeartBar(
+            DrawContext context,
+            PlayerEntity player,
+            LivingEntity mount,
+            Vector2i[] heartPositions,
+            int displayHealth,
+            int maxDisplayHealth
+    ) {
+        renderFireHeartBar(context, mount, heartPositions, maxDisplayHealth);
     }
 
     public static void renderFireHeartBar(
@@ -29,14 +42,24 @@ public class ThermooTestModClient implements ClientModInitializer {
             int displayHealth,
             int maxDisplayHealth
     ) {
-        int fireHeartPoints = getNumFirePoints(player, maxDisplayHealth);
+        renderFireHeartBar(context, player, heartPositions, maxDisplayHealth);
+    }
+
+    private static void renderFireHeartBar(DrawContext context, LivingEntity mount, Vector2i[] heartPositions, int maxDisplayHealth) {
+        int fireHeartPoints = getNumFirePoints(mount, maxDisplayHealth);
         int fireHearts = getNumFireHeartsFromPoints(fireHeartPoints, maxDisplayHealth);
 
         for (int m = 0; m < fireHearts; m++) {
+            Vector2i heartPos = heartPositions[m];
+
+            if (heartPos == null) {
+                continue;
+            }
+
             // is half heart if this is the last heart being rendered and we have an odd
             // number of frozen health points
-            int x = heartPositions[m].x;
-            int y = heartPositions[m].y - 1;
+            int x = heartPos.x;
+            int y = heartPos.y - 1;
             boolean isHalfHeart = m + 1 >= fireHearts && (fireHeartPoints & 1) == 1; // is odd check
 
             int u = isHalfHeart ? 9 : 0;
@@ -45,7 +68,7 @@ public class ThermooTestModClient implements ClientModInitializer {
         }
     }
 
-    private static int getNumFirePoints(@NotNull PlayerEntity player, int maxDisplayHealth) {
+    private static int getNumFirePoints(@NotNull LivingEntity player, int maxDisplayHealth) {
         float tempScale = player.thermoo$getTemperatureScale();
         if (tempScale <= 0f) {
             return 0;

--- a/src/testmod/resources/data/thermoo-test/thermoo/temperature_effects/sequence_test.json
+++ b/src/testmod/resources/data/thermoo-test/thermoo/temperature_effects/sequence_test.json
@@ -26,7 +26,7 @@
                         {
                             "amplifier": 0,
                             "duration": 200,
-                            "effect": "minecraft:nausea"
+                            "effect": "minecraft:speed"
                         }
                     ]
                 }


### PR DESCRIPTION
* Added the event `StatusBarOverlayRenderEvents.AFTER_MOUNT_HEALTH_BAR`, which is very similar to the `AFTER_HEALTH_BAR` event, except it renders after the health bar of the player's current mount (eg, pigs, horses, camels). 