### PR TITLE
Update 3.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.4+build.3
 loader_version=0.15.10
 
 # Mod Properties
-mod_version=3.1.3
+mod_version=3.2
 maven_group=com.github.thedeathlycow
 archives_base_name=thermoo
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/command/EnvironmentCommand.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/command/EnvironmentCommand.java
@@ -23,6 +23,8 @@ import static net.minecraft.server.command.CommandManager.literal;
  * Usage:
  * <p>
  * {@code thermoo environment checktemperature <args>}
+ *
+ * {@code thermoo environment printcontroller}
  */
 public class EnvironmentCommand {
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/command/SoakingCommand.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/command/SoakingCommand.java
@@ -17,8 +17,20 @@ import java.util.function.Supplier;
 import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.server.command.CommandManager.literal;
 
+/**
+ * Command relating to soaking. Allows soaking values to be modified in game.
+ * <p>
+ * Usage:
+ * <p>
+ * {@code thermoo soaking (get|set|add|remove) <target> <args>}
+ */
 public final class SoakingCommand {
 
+    /**
+     * Supplier for creating a new soaking command builder to be registered to the Minecraft server
+     * <p>
+     * Registered by the default implementation of this API.
+     */
     public static final Supplier<LiteralArgumentBuilder<ServerCommandSource>> COMMAND_BUILDER = SoakingCommand::buildCommand;
 
     private static final String TARGET_KEY = "target";

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/command/SoakingCommand.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/command/SoakingCommand.java
@@ -1,0 +1,220 @@
+package com.github.thedeathlycow.thermoo.api.command;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.command.argument.EntityArgumentType;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.MathHelper;
+import org.jetbrains.annotations.Contract;
+
+import java.util.function.Supplier;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+public final class SoakingCommand {
+
+    public static final Supplier<LiteralArgumentBuilder<ServerCommandSource>> COMMAND_BUILDER = SoakingCommand::buildCommand;
+
+    private static final String TARGET_KEY = "target";
+    private static final String SCALE_KEY = "scale";
+    private static final String MIN_KEY = "min";
+    private static final String MAX_KEY = "max";
+    private static final String VALUE_KEY = "value";
+
+    @Contract("->new")
+    private static LiteralArgumentBuilder<ServerCommandSource> buildCommand() {
+        return literal("thermoo").then(
+                (literal("soaking").requires(src -> src.hasPermissionLevel(2)))
+                        .then(buildGetCommand())
+                        .then(buildSetCommand())
+        );
+    }
+
+    private static LiteralArgumentBuilder<ServerCommandSource> buildSetCommand() {
+        return literal("set")
+                .then(
+                        argument(TARGET_KEY, EntityArgumentType.entity())
+                                .then(
+                                        argument(VALUE_KEY, IntegerArgumentType.integer(0))
+                                                .executes(
+                                                        context -> {
+                                                            return set(
+                                                                    context.getSource(),
+                                                                    EntityArgumentType.getEntity(context, TARGET_KEY),
+                                                                    IntegerArgumentType.getInteger(context, VALUE_KEY)
+                                                            );
+                                                        }
+                                                )
+                                )
+                );
+    }
+
+    private static LiteralArgumentBuilder<ServerCommandSource> buildGetCommand() {
+
+        Command<ServerCommandSource> getCurrent = context -> {
+            return getCurrent(
+                    context.getSource(),
+                    EntityArgumentType.getEntity(context, TARGET_KEY)
+            );
+        };
+
+        var getScale = literal(SCALE_KEY)
+                .then(
+                        argument(SCALE_KEY, IntegerArgumentType.integer(1))
+                                .executes(
+                                        context -> {
+                                            return getScale(
+                                                    context.getSource(),
+                                                    EntityArgumentType.getEntity(context, TARGET_KEY),
+                                                    IntegerArgumentType.getInteger(context, SCALE_KEY)
+                                            );
+                                        }
+                                )
+                )
+                .executes(
+                        context -> {
+                            return getScale(
+                                    context.getSource(),
+                                    EntityArgumentType.getEntity(context, TARGET_KEY),
+                                    100
+                            );
+                        }
+                );
+
+        var getMin = literal(MIN_KEY)
+                .executes(
+                        context -> {
+                            return getMin(
+                                    context.getSource(),
+                                    EntityArgumentType.getEntity(context, TARGET_KEY)
+                            );
+                        }
+                );
+
+        var getMax = literal(MAX_KEY)
+                .executes(
+                        context -> {
+                            return getMax(
+                                    context.getSource(),
+                                    EntityArgumentType.getEntity(context, TARGET_KEY)
+                            );
+                        }
+                );
+
+        return literal("get")
+                .then(
+                        argument(TARGET_KEY, EntityArgumentType.entity())
+                                .executes(getCurrent)
+                                .then(literal("current").executes(getCurrent))
+                                .then(getScale)
+                                .then(getMin)
+                                .then(getMax)
+                );
+    }
+
+    private static int set(ServerCommandSource source, Entity target, int value) throws CommandSyntaxException {
+        if (target instanceof LivingEntity entity) {
+            entity.thermoo$setWetTicks(value);
+
+            source.sendFeedback(
+                    () -> Text.translatableWithFallback(
+                            "commands.thermoo.soaking.set.success",
+                            "Set the soaking value of %s to %d (now %d)",
+                            target.getDisplayName(),
+                            value,
+                            entity.thermoo$getWetTicks()
+                    ), false
+            );
+
+            return entity.thermoo$getWetTicks();
+        } else {
+            throw TemperatureCommand.NOT_LIVING_ENTITY.create();
+        }
+    }
+
+    private static int getMax(ServerCommandSource source, Entity target) throws CommandSyntaxException {
+        if (target instanceof LivingEntity entity) {
+            int value = entity.thermoo$getMaxWetTicks();
+
+            source.sendFeedback(
+                    () -> Text.translatableWithFallback(
+                            "commands.thermoo.soaking.get.max.success",
+                            "The maximum soaking value of %s is %d",
+                            target.getDisplayName(),
+                            value
+                    ), false
+            );
+
+            return value;
+        } else {
+            throw TemperatureCommand.NOT_LIVING_ENTITY.create();
+        }
+    }
+
+    private static int getMin(ServerCommandSource source, Entity target) throws CommandSyntaxException {
+        if (target instanceof LivingEntity) {
+            int value = 0;
+
+            source.sendFeedback(
+                    () -> Text.translatableWithFallback(
+                            "commands.thermoo.soaking.get.min.success",
+                            "The minimum soaking value of %s is %d",
+                            target.getDisplayName(),
+                            value
+                    ), false
+            );
+
+            return value;
+        } else {
+            throw TemperatureCommand.NOT_LIVING_ENTITY.create();
+        }
+    }
+
+    private static int getScale(ServerCommandSource source, Entity target, int scale) throws CommandSyntaxException {
+        if (target instanceof LivingEntity entity) {
+            int value = MathHelper.floor(entity.thermoo$getSoakedScale() * scale);
+
+            source.sendFeedback(
+                    () -> Text.translatableWithFallback(
+                            "commands.thermoo.soaking.get.scale.success",
+                            "The current soaking scale of %s is %d",
+                            target.getDisplayName(),
+                            value
+                    ), false
+            );
+
+            return value;
+        } else {
+            throw TemperatureCommand.NOT_LIVING_ENTITY.create();
+        }
+    }
+
+    private static int getCurrent(ServerCommandSource source, Entity target) throws CommandSyntaxException {
+        if (target instanceof LivingEntity entity) {
+            int value = entity.thermoo$getWetTicks();
+
+            source.sendFeedback(
+                    () -> Text.translatableWithFallback(
+                            "commands.thermoo.soaking.get.current.success",
+                            "The current soaking value of %s is %d",
+                            target.getDisplayName(),
+                            value
+                    ), false
+            );
+
+            return value;
+        } else {
+            throw TemperatureCommand.NOT_LIVING_ENTITY.create();
+        }
+    }
+
+    private SoakingCommand() {
+
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/command/SoakingCommand.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/command/SoakingCommand.java
@@ -180,7 +180,7 @@ public final class SoakingCommand {
                             target.getDisplayName(),
                             value,
                             entity.thermoo$getWetTicks()
-                    ), false
+                    ), true
             );
 
             return entity.thermoo$getWetTicks();
@@ -200,7 +200,7 @@ public final class SoakingCommand {
                             target.getDisplayName(),
                             value,
                             entity.thermoo$getWetTicks()
-                    ), false
+                    ), true
             );
 
             return entity.thermoo$getWetTicks();
@@ -220,7 +220,7 @@ public final class SoakingCommand {
                             target.getDisplayName(),
                             value,
                             entity.thermoo$getWetTicks()
-                    ), false
+                    ), true
             );
 
             return entity.thermoo$getWetTicks();

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/command/SoakingCommand.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/command/SoakingCommand.java
@@ -33,7 +33,47 @@ public final class SoakingCommand {
                 (literal("soaking").requires(src -> src.hasPermissionLevel(2)))
                         .then(buildGetCommand())
                         .then(buildSetCommand())
+                        .then(buildAddCommand())
+                        .then(buildRemoveCommand())
         );
+    }
+
+    private static LiteralArgumentBuilder<ServerCommandSource> buildRemoveCommand() {
+        return literal("remove")
+                .then(
+                        argument(TARGET_KEY, EntityArgumentType.entity())
+                                .then(
+                                        argument(VALUE_KEY, IntegerArgumentType.integer(0))
+                                                .executes(
+                                                        context -> {
+                                                            return remove(
+                                                                    context.getSource(),
+                                                                    EntityArgumentType.getEntity(context, TARGET_KEY),
+                                                                    IntegerArgumentType.getInteger(context, VALUE_KEY)
+                                                            );
+                                                        }
+                                                )
+                                )
+                );
+    }
+
+    private static LiteralArgumentBuilder<ServerCommandSource> buildAddCommand() {
+        return literal("add")
+                .then(
+                        argument(TARGET_KEY, EntityArgumentType.entity())
+                                .then(
+                                        argument(VALUE_KEY, IntegerArgumentType.integer(0))
+                                                .executes(
+                                                        context -> {
+                                                            return add(
+                                                                    context.getSource(),
+                                                                    EntityArgumentType.getEntity(context, TARGET_KEY),
+                                                                    IntegerArgumentType.getInteger(context, VALUE_KEY)
+                                                            );
+                                                        }
+                                                )
+                                )
+                );
     }
 
     private static LiteralArgumentBuilder<ServerCommandSource> buildSetCommand() {
@@ -56,7 +96,6 @@ public final class SoakingCommand {
     }
 
     private static LiteralArgumentBuilder<ServerCommandSource> buildGetCommand() {
-
         Command<ServerCommandSource> getCurrent = context -> {
             return getCurrent(
                     context.getSource(),
@@ -116,6 +155,46 @@ public final class SoakingCommand {
                                 .then(getMin)
                                 .then(getMax)
                 );
+    }
+
+    private static int remove(ServerCommandSource source, Entity target, int value) throws CommandSyntaxException {
+        if (target instanceof LivingEntity entity) {
+            entity.thermoo$addWetTicks(-value);
+
+            source.sendFeedback(
+                    () -> Text.translatableWithFallback(
+                            "commands.thermoo.soaking.remove.success",
+                            "Removed %d points from the soaking value of %s (now %d)",
+                            target.getDisplayName(),
+                            value,
+                            entity.thermoo$getWetTicks()
+                    ), false
+            );
+
+            return entity.thermoo$getWetTicks();
+        } else {
+            throw TemperatureCommand.NOT_LIVING_ENTITY.create();
+        }
+    }
+
+    private static int add(ServerCommandSource source, Entity target, int value) throws CommandSyntaxException {
+        if (target instanceof LivingEntity entity) {
+            entity.thermoo$addWetTicks(value);
+
+            source.sendFeedback(
+                    () -> Text.translatableWithFallback(
+                            "commands.thermoo.soaking.add.success",
+                            "Added %d points to the soaking value of %s (now %d)",
+                            target.getDisplayName(),
+                            value,
+                            entity.thermoo$getWetTicks()
+                    ), false
+            );
+
+            return entity.thermoo$getWetTicks();
+        } else {
+            throw TemperatureCommand.NOT_LIVING_ENTITY.create();
+        }
     }
 
     private static int set(ServerCommandSource source, Entity target, int value) throws CommandSyntaxException {

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/command/TemperatureCommand.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/command/TemperatureCommand.java
@@ -29,7 +29,7 @@ import static net.minecraft.server.command.CommandManager.literal;
  */
 public class TemperatureCommand {
 
-    private static final SimpleCommandExceptionType NOT_LIVING_ENTITY = new SimpleCommandExceptionType(
+    static final SimpleCommandExceptionType NOT_LIVING_ENTITY = new SimpleCommandExceptionType(
             Text.translatableWithFallback(
                     "commands.thermoo.temperature.exception.not_living_entity",
                     "Target is not a living entity!"

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/ConfiguredTemperatureEffect.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/ConfiguredTemperatureEffect.java
@@ -31,6 +31,11 @@ import java.util.Optional;
  * @param temperatureScaleRange The temperature scale at which this should be applied to an entity. This is more
  *                              performant than using predicates if you want to apply an effect only within a particular
  *                              temperature range
+ * @param loadingPriority       Priority for loading. Effects with a higher priority at the same resource location will
+ *                              not be overridden by effects with lower priority from other mods/datapacks at the same
+ *                              resource location. Allows mods to reliably override the temperature effects of other
+ *                              mods, regardless of mod load order (which is arbitrary in Fabric). Defaults to 0 if not
+ *                              specified.
  * @param <C>                   The config type
  * @see TemperatureEffect
  */

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/ConfiguredTemperatureEffect.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/ConfiguredTemperatureEffect.java
@@ -39,7 +39,8 @@ public record ConfiguredTemperatureEffect<C>(
         C config,
         Optional<LootCondition> predicate,
         Optional<EntityType<?>> entityType,
-        NumberRange.DoubleRange temperatureScaleRange
+        NumberRange.DoubleRange temperatureScaleRange,
+        int loadingPriority
 ) {
 
     /**

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/FunctionTemperatureEffect.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/FunctionTemperatureEffect.java
@@ -1,0 +1,119 @@
+package com.github.thedeathlycow.thermoo.api.temperature.effects;
+
+import com.github.thedeathlycow.thermoo.impl.Thermoo;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.command.CommandExecutionContext;
+import net.minecraft.command.ReturnValueConsumer;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.StringNbtReader;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.function.*;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.dynamic.Codecs;
+import net.minecraft.util.profiler.Profiler;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public class FunctionTemperatureEffect extends TemperatureEffect<FunctionTemperatureEffect.Config> {
+
+    public static final Codec<Config> CODEC = RecordCodecBuilder.create(
+            instance -> instance.group(
+                    LazyContainer.CODEC
+                            .fieldOf("function")
+                            .forGetter(Config::function),
+                    StringNbtReader.STRINGIFIED_CODEC
+                            .optionalFieldOf("arguments")
+                            .forGetter(Config::arguments),
+                    Codecs.POSITIVE_INT
+                            .fieldOf("interval")
+                            .orElse(20)
+                            .forGetter(Config::interval),
+                    Codec.intRange(0, 4)
+                            .fieldOf("permission_level")
+                            .orElse(2)
+                            .forGetter(Config::permissionLevel)
+            ).apply(instance, Config::new)
+    );
+
+    /**
+     * @param configCodec Codec for the config type
+     */
+    public FunctionTemperatureEffect(Codec<Config> configCodec) {
+        super(configCodec);
+    }
+
+    @Override
+    public void apply(LivingEntity victim, ServerWorld serverWorld, Config config) {
+        MinecraftServer server = serverWorld.getServer();
+        CommandFunctionManager functionManager = server.getCommandFunctionManager();
+
+        config.function.get(functionManager).ifPresent(
+                func -> {
+                    ServerCommandSource commandSource = victim.getCommandSource()
+                            .withSilent()
+                            .withLevel(config.permissionLevel);
+
+                    this.execute(
+                            func,
+                            commandSource,
+                            server,
+                            config.arguments.orElse(null)
+                    );
+                }
+        );
+
+    }
+
+    @Override
+    public boolean shouldApply(LivingEntity victim, Config config) {
+        return config.interval <= 1 || victim.age % config.interval == 0;
+    }
+
+    private void execute(
+            CommandFunction<ServerCommandSource> function,
+            ServerCommandSource source,
+            MinecraftServer server,
+            @Nullable NbtCompound arguments
+    ) {
+        Profiler profiler = server.getProfiler();
+        profiler.push(() -> "function " + function.id());
+
+        try {
+            Procedure<ServerCommandSource> procedure = function.withMacroReplaced(
+                    arguments,
+                    server.getCommandManager().getDispatcher(),
+                    source
+            );
+            CommandManager.callWithContext(
+                    source,
+                    context -> CommandExecutionContext.enqueueProcedureCall(
+                            context,
+                            procedure,
+                            source,
+                            ReturnValueConsumer.EMPTY
+                    )
+            );
+        } catch (MacroException e) {
+            Thermoo.LOGGER.warn("Failed to apply macros to function {}", function.id(), e);
+        } catch (Exception e) {
+            Thermoo.LOGGER.warn("Failed to execute function {}", function.id(), e);
+        } finally {
+            profiler.pop();
+        }
+    }
+
+    public record Config(
+            LazyContainer function,
+            Optional<NbtCompound> arguments,
+            int interval,
+            int permissionLevel
+    ) {
+
+    }
+
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/FunctionTemperatureEffect.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/FunctionTemperatureEffect.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
-public class FunctionTemperatureEffect extends TemperatureEffect<FunctionTemperatureEffect.Config> {
+public final class FunctionTemperatureEffect extends TemperatureEffect<FunctionTemperatureEffect.Config> {
 
     public static final Codec<Config> CODEC = RecordCodecBuilder.create(
             instance -> instance.group(

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffect.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffect.java
@@ -47,16 +47,21 @@ public abstract class TemperatureEffect<C> {
                         NumberRange.DoubleRange.CODEC
                                 .fieldOf("temperature_scale_range")
                                 .orElse(NumberRange.DoubleRange.ANY)
-                                .forGetter(ConfiguredTemperatureEffect::temperatureScaleRange)
+                                .forGetter(ConfiguredTemperatureEffect::temperatureScaleRange),
+                        Codec.INT
+                                .fieldOf("loading_priority")
+                                .orElse(0)
+                                .forGetter(ConfiguredTemperatureEffect::loadingPriority)
                 ).apply(
                         instance,
-                        (config, lootCondition, entityType, doubleRange) -> {
+                        (config, lootCondition, entityType, doubleRange, loadingPriority) -> {
                             return new ConfiguredTemperatureEffect<>(
                                     this,
                                     config,
                                     lootCondition,
                                     entityType,
-                                    doubleRange
+                                    doubleRange,
+                                    loadingPriority
                             );
                         }
                 )

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffects.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffects.java
@@ -24,6 +24,11 @@ public final class TemperatureEffects {
     public static final TemperatureEffect<?> SEQUENCE = new SequenceTemperatureEffect(SequenceTemperatureEffect.CODEC);
 
     /**
+     * A temperature effect that executes a datapack function on an interval
+     */
+    public static final TemperatureEffect<FunctionTemperatureEffect.Config> FUNCTION = new FunctionTemperatureEffect(FunctionTemperatureEffect.CODEC);
+
+    /**
      * Applies {@linkplain  net.minecraft.entity.effect.StatusEffect status effects} to entities based on their
      * temperature
      */

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffects.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffects.java
@@ -16,23 +16,29 @@ public final class TemperatureEffects {
     /**
      * An empty temperature effect; does nothing. Useful for overriding effects from mods or other datapacks
      */
-    public static final TemperatureEffect<?> EMPTY = new EmptyTemperatureEffect(EmptyTemperatureEffect.CODEC);
+    public static final TemperatureEffect<EmptyTemperatureEffect.Config> EMPTY = new EmptyTemperatureEffect(
+            EmptyTemperatureEffect.CODEC
+    );
 
     /**
      * A meta temperature effect that allows multiple child effects to be applied under the same conditions.
      */
-    public static final TemperatureEffect<?> SEQUENCE = new SequenceTemperatureEffect(SequenceTemperatureEffect.CODEC);
+    public static final TemperatureEffect<SequenceTemperatureEffect.Config> SEQUENCE = new SequenceTemperatureEffect(
+            SequenceTemperatureEffect.CODEC
+    );
 
     /**
      * A temperature effect that executes a datapack function on an interval
      */
-    public static final TemperatureEffect<FunctionTemperatureEffect.Config> FUNCTION = new FunctionTemperatureEffect(FunctionTemperatureEffect.CODEC);
+    public static final TemperatureEffect<FunctionTemperatureEffect.Config> FUNCTION = new FunctionTemperatureEffect(
+            FunctionTemperatureEffect.CODEC
+    );
 
     /**
      * Applies {@linkplain  net.minecraft.entity.effect.StatusEffect status effects} to entities based on their
      * temperature
      */
-    public static final TemperatureEffect<?> STATUS_EFFECT = new StatusEffectTemperatureEffect(
+    public static final TemperatureEffect<StatusEffectTemperatureEffect.Config> STATUS_EFFECT = new StatusEffectTemperatureEffect(
             StatusEffectTemperatureEffect.CODEC
     );
 
@@ -40,7 +46,7 @@ public final class TemperatureEffects {
      * Applies scaled {@linkplain net.minecraft.entity.attribute.EntityAttributeModifier attribute modifiers} to
      * entities based on their temperature
      */
-    public static final TemperatureEffect<?> SCALING_ATTRIBUTE_MODIFIER = new ScalingAttributeModifierTemperatureEffect(
+    public static final TemperatureEffect<ScalingAttributeModifierTemperatureEffect.Config> SCALING_ATTRIBUTE_MODIFIER = new ScalingAttributeModifierTemperatureEffect(
             ScalingAttributeModifierTemperatureEffect.CODEC
     );
 
@@ -49,7 +55,7 @@ public final class TemperatureEffects {
      *
      * @since 1.5
      */
-    public static final TemperatureEffect<?> DAMAGE = new DamageTemperatureEffect(DamageTemperatureEffect.CODEC);
+    public static final TemperatureEffect<DamageTemperatureEffect.Config> DAMAGE = new DamageTemperatureEffect(DamageTemperatureEffect.CODEC);
 
     /**
      * Returns all currently loaded {@link ConfiguredTemperatureEffect}s that are mapped to the {@code entity}'s type.

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
@@ -2,10 +2,7 @@ package com.github.thedeathlycow.thermoo.impl;
 
 import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
 import com.github.thedeathlycow.thermoo.api.attribute.ItemAttributeModifier;
-import com.github.thedeathlycow.thermoo.api.command.EnvironmentCommand;
-import com.github.thedeathlycow.thermoo.api.command.HeatingModeArgumentType;
-import com.github.thedeathlycow.thermoo.api.command.TemperatureCommand;
-import com.github.thedeathlycow.thermoo.api.command.TemperatureUnitArgumentType;
+import com.github.thedeathlycow.thermoo.api.command.*;
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentManager;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.ArgumentTypeRegistry;
@@ -41,6 +38,7 @@ public class Thermoo implements ModInitializer {
                 (dispatcher, registryAccess, environment) -> {
                     dispatcher.register(TemperatureCommand.COMMAND_BUILDER.get());
                     dispatcher.register(EnvironmentCommand.COMMAND_BUILDER.get());
+                    dispatcher.register(SoakingCommand.COMMAND_BUILDER.get());
                 }
         );
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooCommonRegisters.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooCommonRegisters.java
@@ -16,6 +16,7 @@ public class ThermooCommonRegisters {
     public static void registerTemperatureEffects() {
         registerTemperatureEffect("empty", TemperatureEffects.EMPTY);
         registerTemperatureEffect("sequence", TemperatureEffects.SEQUENCE);
+        registerTemperatureEffect("function", TemperatureEffects.FUNCTION);
         registerTemperatureEffect("status_effect", TemperatureEffects.STATUS_EFFECT);
         registerTemperatureEffect("scaling_attribute_modifier", TemperatureEffects.SCALING_ATTRIBUTE_MODIFIER);
         registerTemperatureEffect("damage", TemperatureEffects.DAMAGE);

--- a/src/main/resources/assets/thermoo/lang/en_us.json
+++ b/src/main/resources/assets/thermoo/lang/en_us.json
@@ -25,5 +25,7 @@
     "commands.thermoo.soaking.get.scale.success": "The current soaking scale of %s is %d",
     "commands.thermoo.soaking.get.min.success": "The minimum soaking value of %s is %d",
     "commands.thermoo.soaking.get.max.success": "The maximum soaking value of %s is %d",
-    "commands.thermoo.soaking.set.success": "Set the soaking value of %s to %d (now %d)"
+    "commands.thermoo.soaking.set.success": "Set the soaking value of %s to %d (now %d)",
+    "commands.thermoo.soaking.add.success": "Added %d points to the soaking value of %s (now %d)",
+    "commands.thermoo.soaking.remove.success": "Removed %d points from the soaking value of %s (now %d)"
 }

--- a/src/main/resources/assets/thermoo/lang/en_us.json
+++ b/src/main/resources/assets/thermoo/lang/en_us.json
@@ -19,6 +19,11 @@
     "commands.thermoo.environment.printcontroller.success": "Controller logged to console",
 
     "commands.thermoo.environment.checktemperature.success": "The passive temperature change at %s, %s, %s (%s) is %s",
-    "commands.thermoo.environment.checktemperature.unit.success": "The temperature at %s, %s, %s (%s) is %s°%s"
+    "commands.thermoo.environment.checktemperature.unit.success": "The temperature at %s, %s, %s (%s) is %s°%s",
     
+    "commands.thermoo.soaking.get.current.success": "The current soaking value of %s is %d",
+    "commands.thermoo.soaking.get.scale.success": "The current soaking scale of %s is %d",
+    "commands.thermoo.soaking.get.min.success": "The minimum soaking value of %s is %d",
+    "commands.thermoo.soaking.get.max.success": "The maximum soaking value of %s is %d",
+    "commands.thermoo.soaking.set.success": "Set the soaking value of %s to %d (now %d)"
 }

--- a/src/testmod/resources/data/thermoo-test/functions/macro_message.mcfunction
+++ b/src/testmod/resources/data/thermoo-test/functions/macro_message.mcfunction
@@ -1,0 +1,2 @@
+
+$tellraw @s "$(message)"

--- a/src/testmod/resources/data/thermoo-test/functions/message.mcfunction
+++ b/src/testmod/resources/data/thermoo-test/functions/message.mcfunction
@@ -1,0 +1,2 @@
+
+tellraw @s "No macros here!"

--- a/src/testmod/resources/data/thermoo-test/thermoo/temperature_effects/function_macro_test.json
+++ b/src/testmod/resources/data/thermoo-test/thermoo/temperature_effects/function_macro_test.json
@@ -1,0 +1,13 @@
+{
+    "type": "thermoo:function",
+    "temperature_scale_range": {
+        "min": 0.5
+    },
+    "entity_type": "minecraft:player",
+    "config": {
+        "function": "thermoo-test:notify_temperature",
+        "interval": 20,
+        "arguments": "{message:\"Hi there!\"}",
+        "permission_level": 2
+    }
+}

--- a/src/testmod/resources/data/thermoo-test/thermoo/temperature_effects/function_macro_test.json
+++ b/src/testmod/resources/data/thermoo-test/thermoo/temperature_effects/function_macro_test.json
@@ -5,7 +5,7 @@
     },
     "entity_type": "minecraft:player",
     "config": {
-        "function": "thermoo-test:notify_temperature",
+        "function": "thermoo-test:macro_message",
         "interval": 20,
         "arguments": "{message:\"Hi there!\"}",
         "permission_level": 2

--- a/src/testmod/resources/data/thermoo-test/thermoo/temperature_effects/function_test.json
+++ b/src/testmod/resources/data/thermoo-test/thermoo/temperature_effects/function_test.json
@@ -1,0 +1,10 @@
+{
+    "type": "thermoo:function",
+    "temperature_scale_range": {
+        "min": 0.5
+    },
+    "entity_type": "minecraft:player",
+    "config": {
+        "function": "thermoo-test:message"
+    }
+}

--- a/src/testmod/resources/data/thermoo-test/thermoo/temperature_effects/mod_does_not_exist_test.json
+++ b/src/testmod/resources/data/thermoo-test/thermoo/temperature_effects/mod_does_not_exist_test.json
@@ -1,0 +1,20 @@
+{
+    "type": "thermoo:function",
+    "temperature_scale_range": {
+        "min": 0.5
+    },
+    "entity_type": "minecraft:player",
+    "config": {
+        "function": "thermoo-test:macro_message",
+        "interval": 100,
+        "arguments": "{message:\"Frostiful exists!\"}"
+    },
+    "fabric:load_conditions": [
+        {
+            "condition": "fabric:all_mods_loaded",
+            "values": [
+                "frostiful"
+            ]
+        }
+    ]
+}

--- a/src/testmod/resources/data/thermoo-test/thermoo/temperature_effects/mod_exists_test.json
+++ b/src/testmod/resources/data/thermoo-test/thermoo/temperature_effects/mod_exists_test.json
@@ -1,0 +1,20 @@
+{
+    "type": "thermoo:function",
+    "temperature_scale_range": {
+        "min": 0.5
+    },
+    "entity_type": "minecraft:player",
+    "config": {
+        "function": "thermoo-test:macro_message",
+        "interval": 100,
+        "arguments": "{message:\"Thermoo exists!\"}"
+    },
+    "fabric:load_conditions": [
+        {
+            "condition": "fabric:all_mods_loaded",
+            "values": [
+                "thermoo"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This update adds new features to temperature effects, and a new command

* Resolves #15: Fabric resource conditions may now be applied to temperature effects
* Resolves #16: Added a new `soaking` command to read and write to an entity's soaking value
* Resolves #19: Added optional `loading_priority` to temperature effects
* Loading priority allows for load-order independent overriding of temperature effects between mods and datapacks to allow for easier compatibility patching
* Resolves #20: Added new temperature effect type `thermoo:function`
* Function temperature effects run a datapack function on a regular interval. The config provides options for the function to execute, the length of the interval (in ticks), the permission level of the function to execute, and the macro arguments of the function. The execution context of the function will be `as` and `at` the entity.