### PR TITLE
[1.20.1] fix changes in latest colorful hearts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.5-SNAPSHOT'
+    id 'fabric-loom' version '1.6-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ cca_version=5.2.2
 
 # Health bar mods
 overflowing_bars_version=v8.0.0-1.20.1-Fabric
-colorful_hearts_version=4.0.4
+colorful_hearts_version=4.1.8-fabric
 
 # Seasons mods
 fabric_seasons_version=2.3+1.20

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/compat/colorfulhearts/present/HeartRendererMixin.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/compat/colorfulhearts/present/HeartRendererMixin.java
@@ -12,8 +12,9 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
-import terrails.colorfulhearts.heart.Heart;
-import terrails.colorfulhearts.heart.HeartType;
+import terrails.colorfulhearts.api.event.HeartRenderEvent;
+import terrails.colorfulhearts.api.heart.drawing.Heart;
+import terrails.colorfulhearts.api.heart.drawing.OverlayHeart;
 import terrails.colorfulhearts.render.HeartRenderer;
 
 import java.util.Arrays;
@@ -25,7 +26,8 @@ public class HeartRendererMixin {
     @Inject(method = "renderPlayerHearts",
             at = @At(
                     value = "INVOKE",
-                    target = "Lterrails/colorfulhearts/heart/Heart;draw(Lnet/minecraft/client/util/math/MatrixStack;IIZZLterrails/colorfulhearts/heart/HeartType;)V",
+                    target = "Lterrails/colorfulhearts/api/heart/drawing/Heart;draw(Lnet/minecraft/client/gui/DrawContext;IIZZZ)V",
+                    ordinal = 0,
                     remap = true,
                     shift = At.Shift.AFTER
             ),
@@ -39,10 +41,12 @@ public class HeartRendererMixin {
             int displayHealth, int absorption,
             boolean renderHighlight,
             CallbackInfo ci,
+            long ticks,
             int healthHearts, int displayHealthHearts,
-            boolean absorptionSameRow,
+            boolean hardcore,
             int regenIndex,
-            HeartType heartType,
+            OverlayHeart heartType,
+            HeartRenderEvent.Pre event,
             int index,
             Heart heart,
             int xPos, int yPos,
@@ -57,8 +61,7 @@ public class HeartRendererMixin {
     @Inject(
             method = "renderPlayerHearts",
             at = @At(
-                    value = "INVOKE",
-                    target = "Lcom/mojang/blaze3d/systems/RenderSystem;disableBlend()V",
+                    value = "TAIL",
                     shift = At.Shift.BEFORE
             )
     )


### PR DESCRIPTION
I have gotten a report that the changes I've done caused crashes with thermoo/frostiful in https://github.com/Terrails/colorful-hearts/issues/25. This should fix it in thermoo at least. I have a companion PR for 1.20.1 Frostiful that will go up shortly as well.

Bumping loom up to 1.6 seems to be a requirement as it wouldn't accept newer versions of colorful hearts due to it being compiled with loom 1.6.