### PR TITLE
Allow entity tags in temperature effect `entity_type` field

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.parallel=true
 
 # Fabric Properties
 minecraft_version=1.21
-yarn_mappings=1.21+build.2
+yarn_mappings=1.21+build.9
 loader_version=0.15.11
 
 # Mod Properties

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/ThermooRegistryKeys.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/ThermooRegistryKeys.java
@@ -1,5 +1,6 @@
 package com.github.thedeathlycow.thermoo.api;
 
+import com.github.thedeathlycow.thermoo.api.temperature.effects.ConfiguredTemperatureEffect;
 import com.github.thedeathlycow.thermoo.api.temperature.effects.TemperatureEffect;
 import com.github.thedeathlycow.thermoo.impl.Thermoo;
 import net.minecraft.registry.Registry;
@@ -8,7 +9,8 @@ import net.minecraft.registry.RegistryKey;
 public final class ThermooRegistryKeys {
 
 
-    public static final RegistryKey<Registry<TemperatureEffect<?>>> TEMPERATURE_EFFECT = createRegistryKey("temperature_effects");
+    public static final RegistryKey<Registry<TemperatureEffect<?>>> TEMPERATURE_EFFECT = createRegistryKey("temperature_effect_type");
+    public static final RegistryKey<Registry<ConfiguredTemperatureEffect<?>>> CONFIGURED_TEMPERATURE_EFFECT = createRegistryKey("temperature_effect");
 
     private static <T> RegistryKey<Registry<T>> createRegistryKey(String registryId) {
         return RegistryKey.ofRegistry(Thermoo.id(registryId));

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/ConfiguredTemperatureEffect.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/ConfiguredTemperatureEffect.java
@@ -2,6 +2,7 @@ package com.github.thedeathlycow.thermoo.api.temperature.effects;
 
 import com.github.thedeathlycow.thermoo.api.ThermooRegistries;
 import com.mojang.serialization.Codec;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.loot.condition.LootCondition;
@@ -10,8 +11,11 @@ import net.minecraft.loot.context.LootContextParameterSet;
 import net.minecraft.loot.context.LootContextParameters;
 import net.minecraft.loot.context.LootContextTypes;
 import net.minecraft.predicate.NumberRange;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.registry.entry.RegistryEntryList;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.world.World;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Optional;
 
@@ -47,7 +51,7 @@ public final class ConfiguredTemperatureEffect<C> {
      * If not null, then only applies this effect to entities of the specific type. This is more
      * performant than using predicates if you want to apply an effect only to one specific type.
      */
-    private final Optional<EntityType<?>> entityType;
+    private final RegistryEntryList<EntityType<?>> entityTypes;
 
     /**
      * The temperature scale at which this should be applied to an entity. This is more
@@ -72,18 +76,18 @@ public final class ConfiguredTemperatureEffect<C> {
      */
     private boolean wasApplied = false;
 
-    public ConfiguredTemperatureEffect(
+    ConfiguredTemperatureEffect(
             TemperatureEffect<C> type,
             C config,
             Optional<LootCondition> predicate,
-            Optional<EntityType<?>> entityType,
+            RegistryEntryList<EntityType<?>> entityTypes,
             NumberRange.DoubleRange temperatureScaleRange,
             int loadingPriority
     ) {
         this.type = type;
         this.config = config;
         this.predicate = predicate;
-        this.entityType = entityType;
+        this.entityTypes = entityTypes;
         this.temperatureScaleRange = temperatureScaleRange;
         this.loadingPriority = loadingPriority;
     }
@@ -151,8 +155,21 @@ public final class ConfiguredTemperatureEffect<C> {
         return predicate;
     }
 
+    public RegistryEntryList<EntityType<?>> entityTypes() {
+        return entityTypes;
+    }
+
+    /**
+     *
+     * @return Returns the first entity type in {@link #entityTypes}, if present
+     * @deprecated Use {@link #entityTypes()}
+     */
+    @Deprecated(since = "4.2")
     public Optional<EntityType<?>> entityType() {
-        return entityType;
+        if (this.entityTypes.size() > 0) {
+            return Optional.of(this.entityTypes.get(0).value());
+        }
+        return Optional.empty();
     }
 
     public NumberRange.DoubleRange temperatureScaleRange() {

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/SequenceTemperatureEffect.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/SequenceTemperatureEffect.java
@@ -1,10 +1,13 @@
 package com.github.thedeathlycow.thermoo.api.temperature.effects;
 
+import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.registry.RegistryCodecs;
 import net.minecraft.registry.entry.RegistryEntryList;
+import net.minecraft.registry.entry.RegistryEntryListCodec;
 import net.minecraft.server.world.ServerWorld;
 
 import java.util.List;
@@ -17,7 +20,11 @@ public class SequenceTemperatureEffect extends TemperatureEffect<SequenceTempera
 
     public static final Codec<Config> CODEC = RecordCodecBuilder.create(
             instance -> instance.group(
-                    Codec.list(ConfiguredTemperatureEffect.CODEC)
+                    RegistryCodecs.entryList(
+                                    ThermooRegistryKeys.CONFIGURED_TEMPERATURE_EFFECT,
+                                    ConfiguredTemperatureEffect.CODEC,
+                                    true
+                            )
                             .fieldOf("children")
                             .forGetter(Config::children)
             ).apply(instance, Config::new)
@@ -29,10 +36,10 @@ public class SequenceTemperatureEffect extends TemperatureEffect<SequenceTempera
 
     @Override
     public void apply(LivingEntity victim, ServerWorld serverWorld, Config config) {
-        for (ConfiguredTemperatureEffect<?> child : config.children()) {
-            RegistryEntryList<EntityType<?>> allowedTypes = child.entityTypes();
-            if (victim.getType().isIn(allowedTypes)) {
-                child.applyIfPossible(victim);
+        for (var child : config.children()) {
+            RegistryEntryList<EntityType<?>> allowedTypes = child.value().entityTypes();
+            if (allowedTypes.size() == 0 || victim.getType().isIn(allowedTypes)) {
+                child.value().applyIfPossible(victim);
             }
         }
     }
@@ -42,7 +49,7 @@ public class SequenceTemperatureEffect extends TemperatureEffect<SequenceTempera
         return true;
     }
 
-    public record Config(List<ConfiguredTemperatureEffect<?>> children) {
+    public record Config(RegistryEntryList<ConfiguredTemperatureEffect<?>> children) {
 
     }
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/SequenceTemperatureEffect.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/SequenceTemperatureEffect.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.registry.entry.RegistryEntryList;
 import net.minecraft.server.world.ServerWorld;
 
 import java.util.List;
@@ -29,8 +30,8 @@ public class SequenceTemperatureEffect extends TemperatureEffect<SequenceTempera
     @Override
     public void apply(LivingEntity victim, ServerWorld serverWorld, Config config) {
         for (ConfiguredTemperatureEffect<?> child : config.children()) {
-            EntityType<?> childType = child.entityType().orElse(null);
-            if (childType == null || victim.getType() == childType) {
+            RegistryEntryList<EntityType<?>> allowedTypes = child.entityTypes();
+            if (victim.getType().isIn(allowedTypes)) {
                 child.applyIfPossible(victim);
             }
         }

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffect.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffect.java
@@ -7,6 +7,9 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.loot.condition.LootCondition;
 import net.minecraft.predicate.NumberRange;
 import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryCodecs;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.entry.RegistryEntryList;
 import net.minecraft.server.world.ServerWorld;
 
 /**
@@ -42,9 +45,9 @@ public abstract class TemperatureEffect<C> {
                         LootCondition.CODEC
                                 .optionalFieldOf("entity")
                                 .forGetter(ConfiguredTemperatureEffect::predicate),
-                        Registries.ENTITY_TYPE.getCodec()
-                                .optionalFieldOf("entity_type")
-                                .forGetter(ConfiguredTemperatureEffect::entityType),
+                        RegistryCodecs.entryList(RegistryKeys.ENTITY_TYPE)
+                                .optionalFieldOf("entity_type", RegistryEntryList.of())
+                                .forGetter(ConfiguredTemperatureEffect::entityTypes),
                         NumberRange.DoubleRange.CODEC
                                 .fieldOf("temperature_scale_range")
                                 .orElse(NumberRange.DoubleRange.ANY)
@@ -55,12 +58,12 @@ public abstract class TemperatureEffect<C> {
                                 .forGetter(ConfiguredTemperatureEffect::loadingPriority)
                 ).apply(
                         instance,
-                        (config, lootCondition, entityType, doubleRange, loadingPriority) -> {
+                        (config, lootCondition, entityTypes, doubleRange, loadingPriority) -> {
                             return new ConfiguredTemperatureEffect<>(
                                     this,
                                     config,
                                     lootCondition,
-                                    entityType,
+                                    entityTypes,
                                     doubleRange,
                                     loadingPriority
                             );

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffects.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffects.java
@@ -71,7 +71,7 @@ public final class TemperatureEffects {
      * @return Returns the effects loaded for the entity type
      */
     public static Collection<ConfiguredTemperatureEffect<?>> getEffectsForEntity(LivingEntity entity) {
-        return TemperatureEffectLoader.INSTANCE.getEffectsForEntity(entity);
+        return TemperatureEffectLoader.INSTANCE.getEffectsForEntity(entity, entity.getRegistryManager());
     }
 
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffects.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffects.java
@@ -79,7 +79,7 @@ public final class TemperatureEffects {
      * @return Returns all currently loaded {@link ConfiguredTemperatureEffect}s
      */
     public static Collection<ConfiguredTemperatureEffect<?>> getLoadedConfiguredEffects() {
-        return TemperatureEffectLoader.INSTANCE.getGlobalEffects();
+        return TemperatureEffectLoader.INSTANCE.getLoadedConfiguredEffects();
     }
 
     private TemperatureEffects() {

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/TemperatureEffectLoader.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/TemperatureEffectLoader.java
@@ -16,6 +16,7 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.loot.condition.LootConditionTypes;
 import net.minecraft.predicate.item.ItemPredicate;
+import net.minecraft.registry.DynamicRegistryManager;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.entry.RegistryEntry;
@@ -50,7 +51,10 @@ public class TemperatureEffectLoader implements SimpleSynchronousResourceReloadL
         this.id = id;
     }
 
-    public Collection<ConfiguredTemperatureEffect<?>> getEffectsForEntity(LivingEntity entity) {
+    public Collection<ConfiguredTemperatureEffect<?>> getEffectsForEntity(
+            LivingEntity entity,
+            DynamicRegistryManager manager
+    ) {
         EntityType<?> type = entity.getType();
 
         @SuppressWarnings("deprecation")
@@ -64,7 +68,7 @@ public class TemperatureEffectLoader implements SimpleSynchronousResourceReloadL
                     if (Thermoo.LOGGER.isDebugEnabled()) {
                         Thermoo.LOGGER.debug("Computing temperature effects for {}", key);
                     }
-                    return TemperatureEffects.getLoadedConfiguredEffects()
+                    return manager.get(ThermooRegistryKeys.CONFIGURED_TEMPERATURE_EFFECT)
                             .stream()
                             .filter(configuredEffect -> {
                                 var allowedTypes = configuredEffect.entityTypes();

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/TemperatureEffectLoader.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/TemperatureEffectLoader.java
@@ -2,32 +2,47 @@ package com.github.thedeathlycow.thermoo.impl;
 
 import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
 import com.github.thedeathlycow.thermoo.api.temperature.effects.ConfiguredTemperatureEffect;
+import com.github.thedeathlycow.thermoo.api.temperature.effects.TemperatureEffects;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.JsonOps;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
 import net.fabricmc.fabric.api.resource.conditions.v1.ResourceCondition;
 import net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditions;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.registry.Registries;
+import net.minecraft.loot.condition.LootConditionTypes;
+import net.minecraft.predicate.item.ItemPredicate;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.registry.entry.RegistryEntryList;
 import net.minecraft.resource.Resource;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.Util;
 
 import java.io.BufferedReader;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class TemperatureEffectLoader implements SimpleSynchronousResourceReloadListener {
 
-    public static final TemperatureEffectLoader INSTANCE = new TemperatureEffectLoader(Thermoo.id("temperature_effects"));
+    public static final TemperatureEffectLoader INSTANCE = Util.make(
+            new TemperatureEffectLoader(Thermoo.id("temperature_effects")),
+            loader -> {
+                ServerLifecycleEvents.SERVER_STARTING.register(server -> loader.clearCache());
+                ServerLifecycleEvents.SERVER_STOPPING.register(server -> loader.clearCache());
+                ServerLifecycleEvents.START_DATA_PACK_RELOAD.register((server, resourceManager) -> loader.clearCache());
+            }
+    );
 
-    private final Map<Identifier, ConfiguredTemperatureEffect<?>> globalEffects = new HashMap<>();
+    private final Map<Identifier, ConfiguredTemperatureEffect<?>> registry = new HashMap<>();
 
-    private final Map<Identifier, Set<ConfiguredTemperatureEffect<?>>> typeSpecificEffects = new HashMap<>();
+    private final Map<RegistryKey<EntityType<?>>, Set<ConfiguredTemperatureEffect<?>>> entityTypeCache = new IdentityHashMap<>();
 
     private final Identifier id;
 
@@ -38,19 +53,30 @@ public class TemperatureEffectLoader implements SimpleSynchronousResourceReloadL
     public Collection<ConfiguredTemperatureEffect<?>> getEffectsForEntity(LivingEntity entity) {
         EntityType<?> type = entity.getType();
 
-        Identifier typeId = Registries.ENTITY_TYPE.getId(type);
+        @SuppressWarnings("deprecation")
+        RegistryEntry.Reference<EntityType<?>> entry = type.getRegistryEntry();
 
-        Set<ConfiguredTemperatureEffect<?>> effects = typeSpecificEffects.get(typeId);
+        RegistryKey<EntityType<?>> key = entry.registryKey();
 
-        if (effects == null) {
-            return Collections.emptySet();
-        }
-
-        return effects;
+        return this.entityTypeCache.computeIfAbsent(
+                key,
+                ignored -> {
+                    if (Thermoo.LOGGER.isDebugEnabled()) {
+                        Thermoo.LOGGER.debug("Computing temperature effects for {}", key);
+                    }
+                    return TemperatureEffects.getLoadedConfiguredEffects()
+                            .stream()
+                            .filter(configuredEffect -> {
+                                var allowedTypes = configuredEffect.entityTypes();
+                                return allowedTypes.size() == 0 || type.isIn(allowedTypes);
+                            })
+                            .collect(Collectors.toSet());
+                }
+        );
     }
 
-    public Collection<ConfiguredTemperatureEffect<?>> getGlobalEffects() {
-        return globalEffects.values();
+    public Collection<ConfiguredTemperatureEffect<?>> getLoadedConfiguredEffects() {
+        return this.registry.values();
     }
 
     @Override
@@ -61,7 +87,7 @@ public class TemperatureEffectLoader implements SimpleSynchronousResourceReloadL
     @Override
     public void reload(ResourceManager manager) {
 
-        Map<Identifier, ConfiguredTemperatureEffect<?>> registry = new HashMap<>();
+        Map<Identifier, ConfiguredTemperatureEffect<?>> updatedRegistry = new HashMap<>();
 
         Map<Identifier, List<Resource>> entries = manager.findAllResources(
                 "thermoo/temperature_effect",
@@ -72,33 +98,22 @@ public class TemperatureEffectLoader implements SimpleSynchronousResourceReloadL
             Identifier key = entry.getKey();
             for (var resource : entry.getValue()) {
                 try (BufferedReader reader = resource.getReader()) {
-                    this.loadEffect(registry, key, reader);
+                    this.loadEffect(updatedRegistry, key, reader);
                 } catch (Exception e) {
                     Thermoo.LOGGER.error("An error occurred while loading temperature effect {}: {}", entry.getKey(), e);
                 }
             }
         }
 
-        Map<Identifier, ConfiguredTemperatureEffect<?>> newEffects = new HashMap<>();
-        Map<Identifier, Set<ConfiguredTemperatureEffect<?>>> newTypeEffects = new HashMap<>();
-        this.partitionRegistry(registry, newEffects, newTypeEffects);
+        this.registry.clear();
+        this.registry.putAll(updatedRegistry);
 
-        this.globalEffects.clear();
-        this.globalEffects.putAll(newEffects);
-        this.typeSpecificEffects.clear();
-        this.typeSpecificEffects.putAll(newTypeEffects);
-
-        int numEffects = this.globalEffects.size();
-        int numTypeEffects = this.typeSpecificEffects.values()
-                .stream()
-                .map(Set::size)
-                .reduce(0, Integer::sum);
-        Thermoo.LOGGER.info("Loaded {} global temperature effect{}", numEffects, numEffects == 1 ? "" : "s");
-        Thermoo.LOGGER.info("Loaded {} type specific temperature effect{}", numTypeEffects, numTypeEffects == 1 ? "" : "s");
+        int numEffects = this.registry.size();
+        Thermoo.LOGGER.info("Loaded {} temperature effect{}", numEffects, numEffects == 1 ? "" : "s");
     }
 
     private void loadEffect(
-            Map<Identifier, ConfiguredTemperatureEffect<?>> registry,
+            Map<Identifier, ConfiguredTemperatureEffect<?>> updatedRegistry,
             Identifier id,
             BufferedReader reader
     ) {
@@ -110,15 +125,15 @@ public class TemperatureEffectLoader implements SimpleSynchronousResourceReloadL
             ).getOrThrow().getFirst();
 
             boolean overridden = false;
-            if (registry.containsKey(id)) {
-                ConfiguredTemperatureEffect<?> existingEffect = registry.get(id);
+            if (updatedRegistry.containsKey(id)) {
+                ConfiguredTemperatureEffect<?> existingEffect = updatedRegistry.get(id);
                 if (existingEffect.loadingPriority() > effect.loadingPriority()) {
                     overridden = true;
                 }
             }
 
             if (!overridden) {
-                registry.put(id, effect);
+                updatedRegistry.put(id, effect);
             } else {
                 Thermoo.LOGGER.info("Temperature Effect {} tried to load, but was overridden by a higher priority effect with the same ID.", id);
             }
@@ -161,21 +176,8 @@ public class TemperatureEffectLoader implements SimpleSynchronousResourceReloadL
         return true;
     }
 
-    private void partitionRegistry(
-            Map<Identifier, ConfiguredTemperatureEffect<?>> registry,
-            Map<Identifier, ConfiguredTemperatureEffect<?>> globalEffects,
-            Map<Identifier, Set<ConfiguredTemperatureEffect<?>>> typeEffects
-    ) {
-        registry.forEach((key, value) -> {
-            value.entityType().ifPresentOrElse(
-                    entityType -> {
-                        typeEffects.computeIfAbsent(
-                                Registries.ENTITY_TYPE.getId(entityType),
-                                eid -> new HashSet<>()
-                        ).add(value);
-                    },
-                    () -> globalEffects.put(key, value)
-            );
-        });
+    private void clearCache() {
+        this.entityTypeCache.clear();
+        Thermoo.LOGGER.info("Clearing Entity Type to Temperature Effect cache");
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
@@ -1,10 +1,13 @@
 package com.github.thedeathlycow.thermoo.impl;
 
+import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
 import com.github.thedeathlycow.thermoo.api.command.*;
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentManager;
+import com.github.thedeathlycow.thermoo.api.temperature.effects.ConfiguredTemperatureEffect;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.ArgumentTypeRegistry;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.registry.DynamicRegistries;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.minecraft.command.argument.serialize.ConstantArgumentSerializer;
 import net.minecraft.resource.ResourceType;
@@ -44,9 +47,14 @@ public class Thermoo implements ModInitializer {
         ThermooCommonRegisters.registerTemperatureEffects();
         ThermooCommonRegisters.registerLootConditionTypes();
 
-        ResourceManagerHelper serverManager = ResourceManagerHelper.get(ResourceType.SERVER_DATA);
+        DynamicRegistries.register(
+                ThermooRegistryKeys.CONFIGURED_TEMPERATURE_EFFECT,
+                ConfiguredTemperatureEffect.CODEC
+        );
 
-        serverManager.registerReloadListener(TemperatureEffectLoader.INSTANCE);
+//        ResourceManagerHelper serverManager = ResourceManagerHelper.get(ResourceType.SERVER_DATA);
+//        serverManager.registerReloadListener(TemperatureEffectLoader.INSTANCE);
+
         LOGGER.info("Creating environment manager {}", EnvironmentManager.INSTANCE);
         LOGGER.info("Thermoo initialized");
     }

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/common/TemperatureEffectTickerMixin.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/common/TemperatureEffectTickerMixin.java
@@ -42,10 +42,6 @@ public abstract class TemperatureEffectTickerMixin extends Entity {
             effect.applyIfPossible(instance);
         }
 
-        for (var effect : TemperatureEffects.getLoadedConfiguredEffects()) {
-            effect.applyIfPossible(instance);
-        }
-
         profiler.pop();
     }
 

--- a/src/testmod/resources/data/thermoo-test/tags/entity_type/player_affected.json
+++ b/src/testmod/resources/data/thermoo-test/tags/entity_type/player_affected.json
@@ -1,0 +1,7 @@
+{
+    "replace": false,
+    "values": [
+        "minecraft:player",
+        "minecraft:villager"
+    ]
+}

--- a/src/testmod/resources/data/thermoo-test/thermoo/temperature_effect/attribute_test.json
+++ b/src/testmod/resources/data/thermoo-test/thermoo/temperature_effect/attribute_test.json
@@ -1,6 +1,6 @@
 {
     "type": "thermoo:attribute_modifier",
-    "entity_type": "minecraft:player",
+    "entity_type": "#thermoo-test:player_affected",
     "temperature_scale_range": {
         "min": 0.1,
         "max": 0.2

--- a/src/testmod/resources/data/thermoo-test/thermoo/temperature_effect/sequence_test.json
+++ b/src/testmod/resources/data/thermoo-test/thermoo/temperature_effect/sequence_test.json
@@ -27,11 +27,23 @@
                 "config": {
                     "effects": [
                         {
-                            "amplifier": 0,
+                            "amplifier": 2,
                             "duration": 200,
                             "effect": "minecraft:regeneration"
                         }
                     ]
+                }
+            },
+            {
+                "type": "thermoo:function",
+                "temperature_scale_range": {
+                    "max": -1.0
+                },
+                "config": {
+                    "function": "thermoo-test:macro_message",
+                    "interval": 20,
+                    "arguments": "{message:\"Sequence final!\"}",
+                    "permission_level": 2
                 }
             }
         ]

--- a/src/testmod/resources/data/thermoo-test/thermoo/temperature_effect/status_effect_test.json
+++ b/src/testmod/resources/data/thermoo-test/thermoo/temperature_effect/status_effect_test.json
@@ -9,7 +9,7 @@
             {
                 "amplifier": 0,
                 "duration": 200,
-                "effect": "minecraft:regeneration"
+                "effect": "minecraft:jump_boost"
             }
         ]
     }


### PR DESCRIPTION
Allows entity tags and lists in temperature effect `entity_type` field as a `#` prefixed tag ID or list of direct entity type IDs, for example:

```diff
{
    "type": "thermoo:damage",
-   "entity_type": "minecraft:player", // add a temp effect for each type
+   "entity_type": "#example:heat_affected", // now just use a tag
    "temperature_scale_range": {
        "min": 1.0
    },
    "config": {
        "amount": 1.0,
        "damage_interval": 20,
        "damage_type": "minecraft:in_fire"
    }
}
```

This also makes the temperature effect a proper dynamic registry. However, currently, the loading priority is not doing anything. I need to use `streamAllResources()` to check loading priority and a registry ops to check for the tags. Currently, this does not seem possible without some very bad mixins. 