### PR TITLE
Refactor Heart Overlay Event Mixins

### DIFF
--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/HeartOverlayTracker.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/HeartOverlayTracker.java
@@ -5,9 +5,7 @@ import org.joml.Vector2i;
 
 import java.util.Arrays;
 
-public class HeartOverlayImpl {
-
-    public static final HeartOverlayImpl INSTANCE = new HeartOverlayImpl();
+public class HeartOverlayTracker {
 
     private static final int MAX_OVERLAY_HEARTS = 20;
 
@@ -26,9 +24,4 @@ public class HeartOverlayImpl {
     public Vector2i[] getHeartPositions() {
         return heartPositions;
     }
-
-    private HeartOverlayImpl() {
-
-    }
-
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/HeartOverlayTracker.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/HeartOverlayTracker.java
@@ -17,12 +17,16 @@ public class HeartOverlayTracker {
 
     public void addHeartPosition(int index, int heartX, int heartY) {
         if (index >= heartPositions.length) {
-            heartPositions = Arrays.copyOf(heartPositions, index * 2 + 1);
+            heartPositions = Arrays.copyOf(heartPositions, getNextSize(index));
         }
         heartPositions[index] = new Vector2i(heartX, heartY);
     }
 
     public Vector2i[] getHeartPositions() {
         return heartPositions;
+    }
+
+    static int getNextSize(int index) {
+        return (index - 1) + 10 - ((index - 1) % 10);
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/HeartOverlayTracker.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/HeartOverlayTracker.java
@@ -7,18 +7,19 @@ import java.util.Arrays;
 
 public class HeartOverlayTracker {
 
-    private static final int MAX_OVERLAY_HEARTS = 20;
+    private static final int DEFAULT_SIZE = 10;
 
-    private final Vector2i[] heartPositions = Util.make(() -> {
-        var positions = new Vector2i[MAX_OVERLAY_HEARTS];
+    private Vector2i[] heartPositions = Util.make(() -> {
+        var positions = new Vector2i[DEFAULT_SIZE];
         Arrays.fill(positions, null);
         return positions;
     });
 
-    public void setHeartPosition(int index, int heartX, int heartY) {
-        if (index < heartPositions.length) {
-            heartPositions[index] = new Vector2i(heartX, heartY);
+    public void addHeartPosition(int index, int heartX, int heartY) {
+        if (index >= heartPositions.length) {
+            heartPositions = Arrays.copyOf(heartPositions, index * 2 + 1);
         }
+        heartPositions[index] = new Vector2i(heartX, heartY);
     }
 
     public Vector2i[] getHeartPositions() {

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/InGameHudMountTemperatureMixin.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/InGameHudMountTemperatureMixin.java
@@ -2,8 +2,6 @@ package com.github.thedeathlycow.thermoo.mixin.client;
 
 import com.github.thedeathlycow.thermoo.api.client.StatusBarOverlayRenderEvents;
 import com.github.thedeathlycow.thermoo.impl.client.HeartOverlayTracker;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
@@ -11,13 +9,11 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 import org.joml.Vector2i;
 import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -53,7 +49,7 @@ public abstract class InGameHudMountTemperatureMixin {
         if (tracker.get() == null) {
             tracker.set(new HeartOverlayTracker());
         }
-        tracker.get().setHeartPosition(index, heartX, heartY);
+        tracker.get().addHeartPosition(index, heartX, heartY);
     }
 
     @Inject(
@@ -72,17 +68,14 @@ public abstract class InGameHudMountTemperatureMixin {
         float health = mount.getHealth();
         float maxHealth = mount.getMaxHealth();
 
-        int displayHealth = Math.min(MathHelper.ceil(health), heartPositions.length);
-        int maxDisplayHealth = Math.min(MathHelper.ceil(maxHealth), heartPositions.length);
-
         StatusBarOverlayRenderEvents.AFTER_MOUNT_HEALTH_BAR.invoker()
                 .render(
                         context,
                         player,
                         mount,
                         heartPositions,
-                        displayHealth,
-                        maxDisplayHealth
+                        MathHelper.ceil(health),
+                        MathHelper.ceil(maxHealth)
                 );
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/InGameHudMountTemperatureMixin.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/InGameHudMountTemperatureMixin.java
@@ -1,9 +1,12 @@
 package com.github.thedeathlycow.thermoo.mixin.client;
 
 import com.github.thedeathlycow.thermoo.api.client.StatusBarOverlayRenderEvents;
-import com.github.thedeathlycow.thermoo.impl.client.HeartOverlayImpl;
+import com.github.thedeathlycow.thermoo.impl.client.HeartOverlayTracker;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.entity.LivingEntity;
@@ -11,6 +14,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 import org.joml.Vector2i;
+import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -18,22 +22,19 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Arrays;
-
 /**
  * For the mount health bar. For the player health bar see {@link InGameHudPlayerTemperatureMixin}
  */
 @Mixin(InGameHud.class)
+@Debug(export = true)
 public abstract class InGameHudMountTemperatureMixin {
     @Shadow
     protected abstract LivingEntity getRiddenEntity();
 
-    @Shadow protected abstract PlayerEntity getCameraPlayer();
+    @Shadow
+    protected abstract PlayerEntity getCameraPlayer();
 
-    @Unique
-    private int scorchful$mountIndex = 0;
-
-    @WrapOperation(
+    @Inject(
             method = "renderMountHealth",
             at = @At(
                     value = "INVOKE",
@@ -41,18 +42,30 @@ public abstract class InGameHudMountTemperatureMixin {
                     ordinal = 0
             )
     )
-    private void captureMountHealth(DrawContext instance, Identifier texture, int x, int y, int width, int height, Operation<Void> original) {
-        HeartOverlayImpl.INSTANCE.setHeartPosition(scorchful$mountIndex, x, y);
-        original.call(instance, texture, x, y, width, height);
-        scorchful$mountIndex++;
+    private void captureMountHealth(
+            DrawContext context,
+            CallbackInfo ci,
+            @Local(ordinal = 7) int index,
+            @Local(ordinal = 8) int heartX,
+            @Local(ordinal = 4) int heartY,
+            @Share("thermoo_tracker") LocalRef<HeartOverlayTracker> tracker
+    ) {
+        if (tracker.get() == null) {
+            tracker.set(new HeartOverlayTracker());
+        }
+        tracker.get().setHeartPosition(index, heartX, heartY);
     }
 
     @Inject(
             method = "renderMountHealth",
             at = @At("TAIL")
     )
-    private void renderMountHealth(DrawContext context, CallbackInfo ci) {
-        Vector2i[] heartPositions = HeartOverlayImpl.INSTANCE.getHeartPositions();
+    private void renderMountHealth(
+            DrawContext context,
+            CallbackInfo ci,
+            @Share("thermoo_tracker") LocalRef<HeartOverlayTracker> tracker
+    ) {
+        Vector2i[] heartPositions = tracker.get().getHeartPositions();
 
         PlayerEntity player = this.getCameraPlayer();
         LivingEntity mount = this.getRiddenEntity();
@@ -71,7 +84,5 @@ public abstract class InGameHudMountTemperatureMixin {
                         displayHealth,
                         maxDisplayHealth
                 );
-        Arrays.fill(HeartOverlayImpl.INSTANCE.getHeartPositions(), null);
-        scorchful$mountIndex = 0;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/InGameHudPlayerTemperatureMixin.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/InGameHudPlayerTemperatureMixin.java
@@ -11,13 +11,9 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.MathHelper;
 import org.joml.Vector2i;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
-
-import java.util.Arrays;
 
 @Mixin(InGameHud.class)
 public abstract class InGameHudPlayerTemperatureMixin {
@@ -51,7 +47,7 @@ public abstract class InGameHudPlayerTemperatureMixin {
             tracker.set(new HeartOverlayTracker());
         }
 
-        tracker.get().setHeartPosition(index, heartX, heartY);
+        tracker.get().addHeartPosition(index, heartX, heartY);
     }
 
     @Inject(
@@ -75,15 +71,14 @@ public abstract class InGameHudPlayerTemperatureMixin {
             @Share("thermoo_tracker") LocalRef<HeartOverlayTracker> tracker
     ) {
         Vector2i[] heartPositions = tracker.get().getHeartPositions();
-        int displayHealth = Math.min(health, heartPositions.length);
-        int maxDisplayHealth = Math.min(MathHelper.ceil(maxHealth), heartPositions.length);
+        int maxDisplayHealth = MathHelper.ceil(maxHealth);
 
         StatusBarOverlayRenderEvents.AFTER_HEALTH_BAR.invoker()
                 .render(
                         context,
                         player,
                         heartPositions,
-                        displayHealth,
+                        health,
                         maxDisplayHealth
                 );
     }

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/InGameHudPlayerTemperatureMixin.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/client/InGameHudPlayerTemperatureMixin.java
@@ -1,13 +1,17 @@
 package com.github.thedeathlycow.thermoo.mixin.client;
 
 import com.github.thedeathlycow.thermoo.api.client.StatusBarOverlayRenderEvents;
-import com.github.thedeathlycow.thermoo.impl.client.HeartOverlayImpl;
+import com.github.thedeathlycow.thermoo.impl.client.HeartOverlayTracker;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.MathHelper;
 import org.joml.Vector2i;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -23,10 +27,8 @@ public abstract class InGameHudPlayerTemperatureMixin {
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/client/gui/hud/InGameHud;drawHeart(Lnet/minecraft/client/gui/DrawContext;Lnet/minecraft/client/gui/hud/InGameHud$HeartType;IIZZZ)V",
-                    ordinal = 0,
-                    shift = At.Shift.AFTER
-            ),
-            locals = LocalCapture.CAPTURE_FAILEXCEPTION
+                    ordinal = 0
+            )
     )
     private void captureHeartPositions(
             DrawContext context,
@@ -40,16 +42,16 @@ public abstract class InGameHudPlayerTemperatureMixin {
             int absorption,
             boolean blinking,
             CallbackInfo ci,
-            InGameHud.HeartType heartType,
-            boolean bl,
-            int displayHearts,
-            int displayAbsorption,
-            int displayHalfHearts,
-            int index,
-            int lineY, int lineX,
-            int heartX, int heartY
+            @Local(ordinal = 10) int index,
+            @Local(ordinal = 13) int heartX,
+            @Local(ordinal = 14) int heartY,
+            @Share("thermoo_tracker") LocalRef<HeartOverlayTracker> tracker
     ) {
-        HeartOverlayImpl.INSTANCE.setHeartPosition(index, heartX, heartY);
+        if (tracker.get() == null) {
+            tracker.set(new HeartOverlayTracker());
+        }
+
+        tracker.get().setHeartPosition(index, heartX, heartY);
     }
 
     @Inject(
@@ -69,10 +71,10 @@ public abstract class InGameHudPlayerTemperatureMixin {
             int health,
             int absorption,
             boolean blinking,
-            CallbackInfo ci
+            CallbackInfo ci,
+            @Share("thermoo_tracker") LocalRef<HeartOverlayTracker> tracker
     ) {
-
-        Vector2i[] heartPositions = HeartOverlayImpl.INSTANCE.getHeartPositions();
+        Vector2i[] heartPositions = tracker.get().getHeartPositions();
         int displayHealth = Math.min(health, heartPositions.length);
         int maxDisplayHealth = Math.min(MathHelper.ceil(maxHealth), heartPositions.length);
 
@@ -84,7 +86,6 @@ public abstract class InGameHudPlayerTemperatureMixin {
                         displayHealth,
                         maxDisplayHealth
                 );
-        Arrays.fill(HeartOverlayImpl.INSTANCE.getHeartPositions(), null);
     }
 
 }

--- a/src/test/java/com/github/thedeathlycow/thermoo/impl/client/HeartOverlayTrackerTest.java
+++ b/src/test/java/com/github/thedeathlycow/thermoo/impl/client/HeartOverlayTrackerTest.java
@@ -1,0 +1,35 @@
+package com.github.thedeathlycow.thermoo.impl.client;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class HeartOverlayTrackerTest {
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+    void nextSizeIsTen(int index) {
+        int value = HeartOverlayTracker.getNextSize(index);
+        Assertions.assertEquals(10, value);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {11, 12, 13, 14, 15, 16, 17, 18, 19, 20})
+    void nextSizeIsTwenty(int index) {
+        int value = HeartOverlayTracker.getNextSize(index);
+        Assertions.assertEquals(20, value);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {21, 22, 23, 24, 25, 26, 27, 28, 29, 30})
+    void nextSizeIsThirty(int index) {
+        int value = HeartOverlayTracker.getNextSize(index);
+        Assertions.assertEquals(30, value);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {31, 32, 33, 34, 35, 36, 37, 38, 39, 40})
+    void nextSizeIsForty(int index) {
+        int value = HeartOverlayTracker.getNextSize(index);
+        Assertions.assertEquals(40, value);
+    }
+}


### PR DESCRIPTION
Resolves some old tech debt with new Mixin Extras syntax sugar. This improves the thread safety of the health overlay events, and also allows them to respond to any health size (there is no longer a hard cap of 40 hearts to be displayed at most). 

Still need to test the responsive health bar for mounts, but otherwise this is hopefully good to go as is. 