### PR TITLE
Environment temperature entity command

### DIFF
--- a/src/main/java/com/github/thedeathlycow/thermoo/api/command/EnvironmentCommand.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/command/EnvironmentCommand.java
@@ -249,13 +249,17 @@ public class EnvironmentCommand {
         context.components = lookup.findEnvironmentComponents(context.world(), context.pos());
 
         int tempChange = ServerPlayerEnvironmentTickEvents.GET_TEMPERATURE_CHANGE.invoker().addPointChange(context);
+        double resistance = tempChange != 0
+                ? tempChange > 0 ? target.thermoo$getEnvironmentHeatResistance() : target.thermoo$getEnvironmentColdResistance()
+                : 0.0;
 
         source.sendFeedback(
                 () -> Text.translatableWithFallback(
                         "commands.thermoo.environment.temperature.player.success",
-                        "The environment temperature change of %s is %s",
+                        "The environment temperature change of %s is %s (with a %s chance to dodge)",
                         target.getDisplayName(),
-                        tempChange
+                        tempChange,
+                        "%.2f%%".formatted(resistance * 100)
                 ),
                 false
         );

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/command/EnvironmentCommand.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/command/EnvironmentCommand.java
@@ -4,17 +4,24 @@ import com.github.thedeathlycow.thermoo.api.environment.EnvironmentLookup;
 import com.github.thedeathlycow.thermoo.api.environment.component.EnvironmentComponentTypes;
 import com.github.thedeathlycow.thermoo.api.environment.component.RelativeHumidityComponent;
 import com.github.thedeathlycow.thermoo.api.environment.component.TemperatureRecordComponent;
+import com.github.thedeathlycow.thermoo.api.environment.event.EnvironmentTickContext;
+import com.github.thedeathlycow.thermoo.api.environment.event.ServerPlayerEnvironmentTickEvents;
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentManager;
 import com.github.thedeathlycow.thermoo.api.util.TemperatureConverter;
 import com.github.thedeathlycow.thermoo.api.util.TemperatureUnit;
+import com.github.thedeathlycow.thermoo.impl.LivingEntityTickUtil;
 import com.github.thedeathlycow.thermoo.impl.Thermoo;
 import com.github.thedeathlycow.thermoo.impl.environment.EnvironmentLookupImpl;
+import com.github.thedeathlycow.thermoo.impl.environment.ServerPlayerTickUtil;
 import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import net.minecraft.command.argument.BlockPosArgumentType;
 import net.minecraft.command.argument.EntityArgumentType;
+import net.minecraft.component.ComponentMap;
+import net.minecraft.entity.Entity;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -136,13 +143,22 @@ public class EnvironmentCommand {
                 );
 
         final String location = "location";
+        final String target = "target";
         final String unit = "unit";
         final String scale = "scale";
         final TemperatureUnit fallbackUnit = TemperatureUnit.CELSIUS;
         final double fallbackTempScale = 1.0;
 
-        var temperature = literal("temperature").then(
-                argument(location, BlockPosArgumentType.blockPos())
+        var temperature = literal("temperature")
+                .then(argument(target, EntityArgumentType.player())
+                        .executes(
+                                context -> executeEntityTemperature(
+                                        context.getSource(),
+                                        EntityArgumentType.getPlayer(context, target)
+                                )
+                        )
+                )
+                .then(argument(location, BlockPosArgumentType.blockPos())
                         .executes(
                                 context -> executeTemperature(
                                         context.getSource(),
@@ -173,7 +189,7 @@ public class EnvironmentCommand {
                                                         )
                                         )
                         )
-        );
+                );
 
         final double fallbackHumidityScale = 100.0;
 
@@ -225,6 +241,26 @@ public class EnvironmentCommand {
 
         Thermoo.LOGGER.info("The current controller is: {}", controller);
         return 0;
+    }
+
+    private static int executeEntityTemperature(ServerCommandSource source, ServerPlayerEntity target) {
+        final ServerPlayerTickUtil.EnvironmentTickContextImpl context = ServerPlayerTickUtil.createContext(target);
+        final var lookup = EnvironmentLookup.getInstance();
+        context.components = lookup.findEnvironmentComponents(context.world(), context.pos());
+
+        int tempChange = ServerPlayerEnvironmentTickEvents.GET_TEMPERATURE_CHANGE.invoker().addPointChange(context);
+
+        source.sendFeedback(
+                () -> Text.translatableWithFallback(
+                        "commands.thermoo.environment.temperature.player.success",
+                        "The environment temperature change of %s is %s",
+                        target.getDisplayName(),
+                        tempChange
+                ),
+                false
+        );
+
+        return tempChange;
     }
 
     private static int executeTemperature(ServerCommandSource source, BlockPos location, TemperatureUnit unit, double scale) {

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/ServerPlayerTickUtil.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/ServerPlayerTickUtil.java
@@ -14,16 +14,20 @@ import net.minecraft.util.math.BlockPos;
 import org.jetbrains.annotations.NotNull;
 
 public final class ServerPlayerTickUtil {
+    public static EnvironmentTickContextImpl createContext(ServerPlayerEntity player) {
+        return new EnvironmentTickContextImpl(
+                player,
+                player.getServerWorld(),
+                LivingEntityTickUtil.getTemperatureTickPos(player)
+        );
+    }
+
     public static void tickPlayerTemperature(ServerPlayerEntity player) {
         if (player.isDead() || player.isRemoved()) {
             return;
         }
 
-        final EnvironmentTickContextImpl context = new EnvironmentTickContextImpl(
-                player,
-                player.getServerWorld(),
-                LivingEntityTickUtil.getTemperatureTickPos(player)
-        );
+        final EnvironmentTickContextImpl context = createContext(player);
         if (ServerPlayerEnvironmentTickEvents.ALLOW_TEMPERATURE_UPDATE.invoker().allowUpdate(context) == TriState.FALSE) {
             return;
         }
@@ -44,11 +48,11 @@ public final class ServerPlayerTickUtil {
         return result != TriState.FALSE;
     }
 
-    private static class EnvironmentTickContextImpl implements EnvironmentTickContext<ServerPlayerEntity> {
+    public static class EnvironmentTickContextImpl implements EnvironmentTickContext<ServerPlayerEntity> {
         private final ServerPlayerEntity affected;
         private final ServerWorld world;
         private final BlockPos pos;
-        private ComponentMap components = ComponentMap.EMPTY;
+        public ComponentMap components = ComponentMap.EMPTY;
 
         public EnvironmentTickContextImpl(ServerPlayerEntity affected, ServerWorld world, BlockPos pos) {
             this.affected = affected;

--- a/src/main/resources/assets/thermoo/lang/en_us.json
+++ b/src/main/resources/assets/thermoo/lang/en_us.json
@@ -30,6 +30,8 @@
     
     "commands.thermoo.environment.temperature.success": "The environmental temperature at %s, %s, %s (%s) is %s°%s",
     "commands.thermoo.environment.humidity.success": "The environmental relative humidity at %s, %s, %s (%s) is %s%%",
+    "commands.thermoo.environment.temperature.player.success": "The environment temperature change of %s is %s",
+    
     
     "commands.thermoo.soaking.get.current.success": "The current soaking value of %s is %d",
     "commands.thermoo.soaking.get.scale.success": "The current soaking scale of %s is %d",

--- a/src/main/resources/assets/thermoo/lang/en_us.json
+++ b/src/main/resources/assets/thermoo/lang/en_us.json
@@ -30,7 +30,7 @@
     
     "commands.thermoo.environment.temperature.success": "The environmental temperature at %s, %s, %s (%s) is %s°%s",
     "commands.thermoo.environment.humidity.success": "The environmental relative humidity at %s, %s, %s (%s) is %s%%",
-    "commands.thermoo.environment.temperature.player.success": "The environment temperature change of %s is %s",
+    "commands.thermoo.environment.temperature.player.success": "The environment temperature change of %s is %s (with a %s chance to dodge)",
     
     
     "commands.thermoo.soaking.get.current.success": "The current soaking value of %s is %d",


### PR DESCRIPTION
Adds a new syntax to the environment temperature command that allows the user to query the current temperature point change of a player. This ignores whether the effect is allowed to apply - it only considers the point change calculated by `ServerPlayerEnvironmentTickEvents.GET_TEMPERATURE_CHANGE`

For example:
```mcfunction
thermoo environment temperature @p
# > The environment temperature change of Steve is 2 (with a 0.00% chance to dodge)
```