### PR TITLE
Item attribute modifiers event

### DIFF
--- a/src/main/java/com/github/thedeathlycow/thermoo/api/item/ModifyItemAttributeModifiersCallback.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/item/ModifyItemAttributeModifiersCallback.java
@@ -1,0 +1,22 @@
+package com.github.thedeathlycow.thermoo.api.item;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.component.type.AttributeModifiersComponent;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Experimental
+@FunctionalInterface
+public interface ModifyItemAttributeModifiersCallback {
+    Event<ModifyItemAttributeModifiersCallback> EVENT = EventFactory.createArrayBacked(
+            ModifyItemAttributeModifiersCallback.class,
+            listeners -> (stack, builder) -> {
+                for (ModifyItemAttributeModifiersCallback listener : listeners) {
+                    listener.modifyAttributeModifiers(stack, builder);
+                }
+            }
+    );
+
+    void modifyAttributeModifiers(ItemStack stack, AttributeModifiersComponent.Builder builder);
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/item/ModifyItemAttributeModifiersCallback.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/item/ModifyItemAttributeModifiersCallback.java
@@ -13,9 +13,11 @@ import org.jetbrains.annotations.ApiStatus;
  * This does not modify the actual {@linkplain net.minecraft.component.DataComponentTypes#ATTRIBUTE_MODIFIERS attribute modifiers component},
  * instead it adjusts the attributes that are used when applied to an entity or displaying the tooltip.
  * <p>
+ * Results from this event may be cached on the stack instance.
+ * <p>
  * This is an experimental event, it may not work fully as expected or impact performance. Proceed with caution.
  * <p>
- * <strong>Example</strong>
+ * <strong>Example:</strong>
  * This listener adds max health to all helmets
  * <pre>
  * {@code

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/item/ModifyItemAttributeModifiersCallback.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/item/ModifyItemAttributeModifiersCallback.java
@@ -6,6 +6,11 @@ import net.minecraft.component.type.AttributeModifiersComponent;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * Stack-aware event for modifying the default attribute modifier component of an item.
+ * <p>
+ * Experimental event, it may not work fully as expected or impact performance. Proceed with caution.
+ */
 @ApiStatus.Experimental
 @FunctionalInterface
 public interface ModifyItemAttributeModifiersCallback {

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/item/ModifyItemAttributeModifiersCallback.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/item/ModifyItemAttributeModifiersCallback.java
@@ -7,9 +7,25 @@ import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
- * Stack-aware event for modifying the default attribute modifier component of an item.
+ * Stack-aware event for modifying the default attribute modifier component of an item. This should only be used
+ * for items external to your mod, such as vanilla items or items from other mods.
  * <p>
- * Experimental event, it may not work fully as expected or impact performance. Proceed with caution.
+ * This does not modify the actual {@linkplain net.minecraft.component.DataComponentTypes#ATTRIBUTE_MODIFIERS attribute modifiers component},
+ * instead it adjusts the attributes that are used when applied to an entity or displaying the tooltip.
+ * <p>
+ * This is an experimental event, it may not work fully as expected or impact performance. Proceed with caution.
+ * <p>
+ * <strong>Example</strong>
+ * This listener adds max health to all helmets
+ * <pre>
+ * {@code
+ *  ModifyItemAttributeModifiersCallback.EVENT.register((stack, builder) -> {
+ *  	if (stack.isIn(ItemTags.HEAD_ARMOR)) {
+ *          builder.add(EntityAttributes.MAX_HEALTH, MODIFIER, AttributeModifierSlot.HEAD);
+ *      }
+ *  });
+ * }
+ * </pre>
  */
 @ApiStatus.Experimental
 @FunctionalInterface

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/item/package-info.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/item/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Item related APIs for Thermoo
+ */
+package com.github.thedeathlycow.thermoo.api.item;

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
@@ -6,6 +6,7 @@ import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
 import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProvider;
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentManager;
 import com.github.thedeathlycow.thermoo.impl.environment.EnvironmentLookupImpl;
+import com.github.thedeathlycow.thermoo.impl.item.ModifyItemAttributeModifiersImpl;
 import com.github.thedeathlycow.thermoo.impl.temperature.effect.TemperatureEffectLoader;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.ArgumentTypeRegistry;
@@ -57,6 +58,7 @@ public class Thermoo implements ModInitializer {
         ThermooCommonRegisters.registerTemperatureEffects();
         ThermooCommonRegisters.registerEnvironmentProviderTypes();
         ThermooCommonRegisters.registerLootConditionTypes();
+        ModifyItemAttributeModifiersImpl.initialize();
 
         ResourceManagerHelper serverManager = ResourceManagerHelper.get(ResourceType.SERVER_DATA);
         serverManager.registerReloadListener(TemperatureEffectLoader.ID, TemperatureEffectLoader::new);

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/item/ModifyItemAttributeModifiersImpl.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/item/ModifyItemAttributeModifiersImpl.java
@@ -1,0 +1,56 @@
+package com.github.thedeathlycow.thermoo.impl.item;
+
+import com.github.thedeathlycow.thermoo.api.item.ModifyItemAttributeModifiersCallback;
+import com.github.thedeathlycow.thermoo.mixin.common.accessor.AttributeModifiersComponentBuilderAccessor;
+import com.google.common.collect.MapMaker;
+import it.unimi.dsi.fastutil.Pair;
+import net.minecraft.component.type.AttributeModifiersComponent;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.util.Identifier;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class ModifyItemAttributeModifiersImpl {
+    private static final Map<ItemStack, AttributeModifiersComponent> CACHE = new MapMaker()
+            .weakKeys()
+            .makeMap();
+
+    public static AttributeModifiersComponent invoke(ItemStack stack, AttributeModifiersComponent base) {
+        return CACHE.computeIfAbsent(
+                stack,
+                s -> {
+                    AttributeModifiersComponent.Builder builder = AttributeModifiersComponent.builder();
+                    AttributeModifiersComponentBuilderAccessor accessor = (AttributeModifiersComponentBuilderAccessor) builder;
+                    accessor.scorchful$getEntries().addAll(base.modifiers());
+
+                    ModifyItemAttributeModifiersCallback.EVENT.invoker().modifyAttributeModifiers(s, builder);
+
+                    return new AttributeModifiersComponent(removeDuplicates(builder.build().modifiers()), base.showInTooltip());
+                }
+        );
+    }
+
+    private static List<AttributeModifiersComponent.Entry> removeDuplicates(Collection<AttributeModifiersComponent.Entry> modifiers) {
+        Map<Pair<RegistryKey<EntityAttribute>, Identifier>, AttributeModifiersComponent.Entry> map = new LinkedHashMap<>();
+
+        // de-duplicates the modifiers to remove any entries that modify the same attribute and have the same ID
+        for (var modifier : modifiers) {
+            Pair<RegistryKey<EntityAttribute>, Identifier> key = Pair.of(
+                    modifier.attribute().getKey().orElseThrow(),
+                    modifier.modifier().id()
+            );
+            map.put(key, modifier);
+        }
+
+        return map.values().stream().toList();
+    }
+
+    private ModifyItemAttributeModifiersImpl() {
+
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/item/ModifyItemAttributeModifiersImpl.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/item/ModifyItemAttributeModifiersImpl.java
@@ -1,38 +1,59 @@
 package com.github.thedeathlycow.thermoo.impl.item;
 
 import com.github.thedeathlycow.thermoo.api.item.ModifyItemAttributeModifiersCallback;
+import com.github.thedeathlycow.thermoo.impl.Thermoo;
 import com.github.thedeathlycow.thermoo.mixin.common.accessor.AttributeModifiersComponentBuilderAccessor;
-import com.google.common.collect.MapMaker;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
 import it.unimi.dsi.fastutil.Pair;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.component.type.AttributeModifiersComponent;
 import net.minecraft.entity.attribute.EntityAttribute;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.util.Identifier;
+import org.apache.commons.lang3.exception.UncheckedException;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 public final class ModifyItemAttributeModifiersImpl {
-    private static final Map<ItemStack, AttributeModifiersComponent> CACHE = new MapMaker()
+    private static final Cache<ItemStack, AttributeModifiersComponent> CACHE = CacheBuilder.newBuilder()
             .weakKeys()
-            .makeMap();
+            .maximumSize(25L)
+            .build();
+
+    public static void initialize() {
+        ServerLifecycleEvents.START_DATA_PACK_RELOAD.register((server, resourceManager) -> CACHE.invalidateAll());
+        ServerTickEvents.END_SERVER_TICK.register(server -> {
+            if (server.getTicks() % 20 == 0) {
+                Thermoo.LOGGER.info("Modifier cache size: {}", CACHE.size());
+            }
+        });
+    }
 
     public static AttributeModifiersComponent invoke(ItemStack stack, AttributeModifiersComponent base) {
-        return CACHE.computeIfAbsent(
-                stack,
-                s -> {
-                    AttributeModifiersComponent.Builder builder = AttributeModifiersComponent.builder();
-                    AttributeModifiersComponentBuilderAccessor accessor = (AttributeModifiersComponentBuilderAccessor) builder;
-                    accessor.scorchful$getEntries().addAll(base.modifiers());
+        try {
+            return CACHE.get(
+                    stack,
+                    () -> {
+                        AttributeModifiersComponent.Builder builder = AttributeModifiersComponent.builder();
+                        AttributeModifiersComponentBuilderAccessor accessor = (AttributeModifiersComponentBuilderAccessor) builder;
+                        accessor.scorchful$getEntries().addAll(base.modifiers());
 
-                    ModifyItemAttributeModifiersCallback.EVENT.invoker().modifyAttributeModifiers(s, builder);
+                        ModifyItemAttributeModifiersCallback.EVENT.invoker().modifyAttributeModifiers(stack, builder);
 
-                    return new AttributeModifiersComponent(removeDuplicates(builder.build().modifiers()), base.showInTooltip());
-                }
-        );
+                        return new AttributeModifiersComponent(removeDuplicates(builder.build().modifiers()), base.showInTooltip());
+                    }
+            );
+        } catch (ExecutionException e) {
+            throw new UncheckedException(e);
+        }
     }
 
     private static List<AttributeModifiersComponent.Entry> removeDuplicates(Collection<AttributeModifiersComponent.Entry> modifiers) {

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/item/ModifyItemAttributeModifiersImpl.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/item/ModifyItemAttributeModifiersImpl.java
@@ -30,11 +30,6 @@ public final class ModifyItemAttributeModifiersImpl {
 
     public static void initialize() {
         ServerLifecycleEvents.START_DATA_PACK_RELOAD.register((server, resourceManager) -> CACHE.invalidateAll());
-        ServerTickEvents.END_SERVER_TICK.register(server -> {
-            if (server.getTicks() % 20 == 0) {
-                Thermoo.LOGGER.info("Modifier cache size: {}", CACHE.size());
-            }
-        });
     }
 
     public static AttributeModifiersComponent invoke(ItemStack stack, AttributeModifiersComponent base) {

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/item/package-info.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/item/package-info.java
@@ -1,0 +1,4 @@
+@ApiStatus.Internal
+package com.github.thedeathlycow.thermoo.impl.item;
+
+import org.jetbrains.annotations.ApiStatus;

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/common/ItemStackMixin.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/common/ItemStackMixin.java
@@ -1,0 +1,66 @@
+package com.github.thedeathlycow.thermoo.mixin.common;
+
+import com.github.thedeathlycow.thermoo.impl.item.ModifyItemAttributeModifiersImpl;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.component.ComponentChanges;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.AttributeModifierSlot;
+import net.minecraft.component.type.AttributeModifiersComponent;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.entry.RegistryEntry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.function.BiConsumer;
+
+@Mixin(ItemStack.class)
+public abstract class ItemStackMixin {
+    @Shadow
+    public abstract ComponentChanges getComponentChanges();
+
+    @WrapOperation(
+            method = "applyAttributeModifier",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/component/type/AttributeModifiersComponent;applyModifiers(Lnet/minecraft/component/type/AttributeModifierSlot;Ljava/util/function/BiConsumer;)V"
+            )
+    )
+    private void hookItemModifierEvent(
+            AttributeModifiersComponent instance,
+            AttributeModifierSlot slot,
+            BiConsumer<RegistryEntry<EntityAttribute>, EntityAttributeModifier> attributeConsumer,
+            Operation<Void> original
+    ) {
+        // prevent overriding modified components from commands
+        if (this.getComponentChanges().get(DataComponentTypes.ATTRIBUTE_MODIFIERS) == null) {
+            instance = ModifyItemAttributeModifiersImpl.invoke((ItemStack) (Object) this, instance);
+        }
+        original.call(instance, slot, attributeConsumer);
+    }
+
+
+    @WrapOperation(
+            method = "applyAttributeModifiers",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/component/type/AttributeModifiersComponent;applyModifiers(Lnet/minecraft/entity/EquipmentSlot;Ljava/util/function/BiConsumer;)V"
+            )
+    )
+    private void hookItemModifierEvent(
+            AttributeModifiersComponent instance,
+            EquipmentSlot slot,
+            BiConsumer<RegistryEntry<EntityAttribute>, EntityAttributeModifier> attributeConsumer,
+            Operation<Void> original
+    ) {
+        // prevent overriding modified components from commands
+        if (this.getComponentChanges().get(DataComponentTypes.ATTRIBUTE_MODIFIERS) == null) {
+            instance = ModifyItemAttributeModifiersImpl.invoke((ItemStack) (Object) this, instance);
+        }
+        original.call(instance, slot, attributeConsumer);
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/common/accessor/AttributeModifiersComponentBuilderAccessor.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/common/accessor/AttributeModifiersComponentBuilderAccessor.java
@@ -1,0 +1,12 @@
+package com.github.thedeathlycow.thermoo.mixin.common.accessor;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.component.type.AttributeModifiersComponent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(AttributeModifiersComponent.Builder.class)
+public interface AttributeModifiersComponentBuilderAccessor {
+    @Accessor("entries")
+    ImmutableList.Builder<AttributeModifiersComponent.Entry> scorchful$getEntries();
+}

--- a/src/main/resources/thermoo.mixins.json
+++ b/src/main/resources/thermoo.mixins.json
@@ -6,9 +6,11 @@
     "mixins": [
         "EnvironmentAwareEntityMixin",
         "HotFloorMixin",
+        "ItemStackMixin",
         "LivingEntityAttributeMixin",
         "LivingEntityEnvironmentTickMixin",
         "PlayerTemperatureTickMixin",
+        "accessor.AttributeModifiersComponentBuilderAccessor",
         "accessor.ComponentMapBuilderAccessor",
         "datafix.AttributeIdPrefixFixMixin"
     ],

--- a/src/testmod/java/com/github/thedeathlycow/thermoo/testmod/ThermooTestMod.java
+++ b/src/testmod/java/com/github/thedeathlycow/thermoo/testmod/ThermooTestMod.java
@@ -1,20 +1,25 @@
 package com.github.thedeathlycow.thermoo.testmod;
 
 import com.github.thedeathlycow.thermoo.api.ThermooAttributes;
+import com.github.thedeathlycow.thermoo.api.item.ModifyItemAttributeModifiersCallback;
 import com.github.thedeathlycow.thermoo.api.season.ThermooSeason;
 import com.github.thedeathlycow.thermoo.api.season.ThermooSeasonEvents;
 import com.github.thedeathlycow.thermoo.impl.Thermoo;
+import com.github.thedeathlycow.thermoo.testmod.tests.item.ModifyItemAttributeModifiersTest;
 import com.github.thedeathlycow.thermoo.testmod.tick.TestEnvironmentChanges;
 import com.github.thedeathlycow.thermoo.testmod.tick.TestSoakableChanges;
 import com.github.thedeathlycow.thermoo.testmod.tick.TestTemperatureChanges;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleFactory;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleRegistry;
+import net.minecraft.util.Identifier;
 import net.minecraft.world.GameRules;
 
 import java.util.Optional;
 
 public class ThermooTestMod implements ModInitializer {
+    public static final String MODID = Thermoo.MODID + "-test";
+
     public static final GameRules.Key<GameRules.IntRule> CURRENT_SEASON =
             GameRuleRegistry.register(
                     Thermoo.MODID + ".setTestSeason",
@@ -37,6 +42,7 @@ public class ThermooTestMod implements ModInitializer {
         TestTemperatureChanges.initialize();
         TestSoakableChanges.initialize();
         TestEnvironmentChanges.initialize();
+        ModifyItemAttributeModifiersTest.initialize();
 
         ThermooSeasonEvents.GET_CURRENT_SEASON.register(
                 world -> Optional.ofNullable(switch (world.getServer().getGameRules().getInt(CURRENT_SEASON)) {
@@ -55,5 +61,9 @@ public class ThermooTestMod implements ModInitializer {
                     default -> null;
                 })
         );
+    }
+
+    public static Identifier id(String path) {
+        return Identifier.of(MODID, path);
     }
 }

--- a/src/testmod/java/com/github/thedeathlycow/thermoo/testmod/tests/item/ModifyItemAttributeModifiersTest.java
+++ b/src/testmod/java/com/github/thedeathlycow/thermoo/testmod/tests/item/ModifyItemAttributeModifiersTest.java
@@ -1,0 +1,134 @@
+package com.github.thedeathlycow.thermoo.testmod.tests.item;
+
+import com.github.thedeathlycow.thermoo.api.item.ModifyItemAttributeModifiersCallback;
+import com.github.thedeathlycow.thermoo.testmod.ThermooTestMod;
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.AttributeModifierSlot;
+import net.minecraft.component.type.AttributeModifiersComponent;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.registry.tag.ItemTags;
+import net.minecraft.test.GameTest;
+import net.minecraft.test.TestContext;
+import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+
+@SuppressWarnings("unused")
+public class ModifyItemAttributeModifiersTest {
+    public static void initialize() {
+        ModifyItemAttributeModifiersCallback.EVENT.register((stack, builder) -> {
+            if (stack.isOf(Items.DIAMOND_CHESTPLATE)) {
+                builder.add(
+                        EntityAttributes.SCALE,
+                        new EntityAttributeModifier(
+                                ThermooTestMod.id("diamond_chestplate_scale_test"),
+                                1.0,
+                                EntityAttributeModifier.Operation.ADD_VALUE
+                        ),
+                        AttributeModifierSlot.CHEST
+                );
+            }
+
+            if (stack.isIn(ItemTags.AXES)) {
+                builder.add(
+                        EntityAttributes.ARMOR,
+                        new EntityAttributeModifier(
+                                ThermooTestMod.id("diamond_axe_armor_test"),
+                                1.0,
+                                EntityAttributeModifier.Operation.ADD_VALUE
+                        ),
+                        AttributeModifierSlot.MAINHAND
+                );
+            }
+
+            if (stack.isOf(Items.NETHERITE_AXE)) {
+                builder.add(
+                        EntityAttributes.ARMOR,
+                        // duplicate
+                        new EntityAttributeModifier(
+                                ThermooTestMod.id("diamond_axe_armor_test"),
+                                5.0,
+                                EntityAttributeModifier.Operation.ADD_VALUE
+                        ),
+                        AttributeModifierSlot.MAINHAND
+                );
+            }
+        });
+    }
+
+    @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+    public void default_diamond_chestplate_applies_scale(TestContext context) {
+        VillagerEntity villager = context.spawnEntity(EntityType.VILLAGER, BlockPos.ORIGIN);
+        context.expectEntityWithData(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getScale, 1f);
+
+        villager.equipStack(EquipmentSlot.CHEST, Items.DIAMOND_CHESTPLATE.getDefaultStack());
+        context.expectEntityWithDataEnd(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getScale, 2f);
+    }
+
+    @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+    public void default_diamond_chestplate_does_not_apply_scale_when_held(TestContext context) {
+        VillagerEntity villager = context.spawnEntity(EntityType.VILLAGER, BlockPos.ORIGIN);
+        context.expectEntityWithData(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getScale, 1f);
+
+        villager.setStackInHand(Hand.MAIN_HAND, Items.DIAMOND_CHESTPLATE.getDefaultStack());
+        context.expectEntityWithDataEnd(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getScale, 1f);
+    }
+
+    @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+    public void modified_diamond_chestplate_does_not_apply_scale(TestContext context) {
+        VillagerEntity villager = context.spawnEntity(EntityType.VILLAGER, BlockPos.ORIGIN);
+        context.expectEntityWithData(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getScale, 1f);
+
+        ItemStack stack = Items.DIAMOND_CHESTPLATE.getDefaultStack();
+        stack.set(DataComponentTypes.ATTRIBUTE_MODIFIERS, AttributeModifiersComponent.DEFAULT);
+
+        villager.equipStack(EquipmentSlot.CHEST, stack);
+        context.expectEntityWithDataEnd(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getScale, 1f);
+    }
+
+    @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+    public void default_diamond_axe_applies_armor(TestContext context) {
+        VillagerEntity villager = context.spawnEntity(EntityType.VILLAGER, BlockPos.ORIGIN);
+        context.expectEntityWithData(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getArmor, 0);
+
+        villager.setStackInHand(Hand.MAIN_HAND, Items.DIAMOND_AXE.getDefaultStack());
+        context.expectEntityWithDataEnd(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getArmor, 1);
+    }
+
+    @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+    public void default_netherite_axe_overwrites_armor(TestContext context) {
+        VillagerEntity villager = context.spawnEntity(EntityType.VILLAGER, BlockPos.ORIGIN);
+        context.expectEntityWithData(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getArmor, 0);
+
+        villager.setStackInHand(Hand.MAIN_HAND, Items.NETHERITE_AXE.getDefaultStack());
+        context.expectEntityWithDataEnd(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getArmor, 5);
+    }
+
+    @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+    public void default_diamond_axe_does_not_apply_armor_when_worn(TestContext context) {
+        VillagerEntity villager = context.spawnEntity(EntityType.VILLAGER, BlockPos.ORIGIN);
+        context.expectEntityWithData(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getArmor, 0);
+
+        villager.equipStack(EquipmentSlot.HEAD, Items.DIAMOND_AXE.getDefaultStack());
+        context.expectEntityWithDataEnd(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getArmor, 0);
+    }
+
+    @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+    public void modified_diamond_axe_does_not_apply_armor(TestContext context) {
+        VillagerEntity villager = context.spawnEntity(EntityType.VILLAGER, BlockPos.ORIGIN);
+        context.expectEntityWithData(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getArmor, 0);
+
+        ItemStack stack = Items.DIAMOND_AXE.getDefaultStack();
+        stack.set(DataComponentTypes.ATTRIBUTE_MODIFIERS, AttributeModifiersComponent.DEFAULT);
+
+        villager.equipStack(EquipmentSlot.CHEST, stack);
+        context.expectEntityWithDataEnd(BlockPos.ORIGIN, EntityType.VILLAGER, LivingEntity::getArmor, 0);
+    }
+}

--- a/src/testmod/resources/fabric.mod.json
+++ b/src/testmod/resources/fabric.mod.json
@@ -14,6 +14,7 @@
 		],
 		"fabric-gametest": [
 			"com.github.thedeathlycow.thermoo.testmod.tests.AttributeTests",
+			"com.github.thedeathlycow.thermoo.testmod.tests.item.ModifyItemAttributeModifiersTest",
 			"com.github.thedeathlycow.thermoo.testmod.tests.environment.PlainsTemperatureTests",
 			"com.github.thedeathlycow.thermoo.testmod.tests.environment.PlainsHumidityTests",
 			"com.github.thedeathlycow.thermoo.testmod.tests.environment.JungleTemperatureTests",


### PR DESCRIPTION
A proper replacement for the `ArmorMaterialEvents` API that should hopefully be stable across multiple 1.21 versions. This is a very similar event to the Fabric API `ModifyItemAttributeModifiersCallback` event from 1.20, but adapted to work better with the new components system.