### PR TITLE
[1.21.1] Environment Priority Field

### DIFF
--- a/src/main/java/com/github/thedeathlycow/thermoo/api/ThermooAttributes.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/ThermooAttributes.java
@@ -95,7 +95,7 @@ public final class ThermooAttributes {
     public static final RegistryEntry<EntityAttribute> ENVIRONMENT_HEAT_RESISTANCE = register(
             "generic.environment_heat_resistance",
             new ClampedEntityAttribute(
-                    "attribute.thermoo.generic.environment_heat_resistance", 0.0, 0.0, 1.0
+                    "attribute.thermoo.generic.environment_heat_resistance", 0.0, -1.0, 1.0
             ).setTracked(true)
     );
 
@@ -109,7 +109,7 @@ public final class ThermooAttributes {
     public static final RegistryEntry<EntityAttribute> ENVIRONMENT_FROST_RESISTANCE = register(
             "generic.environment_frost_resistance",
             new ClampedEntityAttribute(
-                    "attribute.thermoo.generic.environment_frost_resistance", 0.0, 0.0, 1.0
+                    "attribute.thermoo.generic.environment_frost_resistance", 0.0, -1.0, 1.0
             ).setTracked(true)
     );
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/command/EnvironmentCommand.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/command/EnvironmentCommand.java
@@ -251,16 +251,30 @@ public class EnvironmentCommand {
                 ? tempChange > 0 ? target.thermoo$getEnvironmentHeatResistance() : target.thermoo$getEnvironmentColdResistance()
                 : 0.0;
 
-        source.sendFeedback(
-                () -> Text.translatableWithFallback(
-                        "commands.thermoo.environment.temperature.player.success",
-                        "The environment temperature change of %s is %s (with a %s chance to dodge)",
-                        target.getDisplayName(),
-                        tempChange,
-                        "%.2f%%".formatted(resistance * 100)
-                ),
-                false
-        );
+        if (resistance >= 0) {
+            source.sendFeedback(
+                    () -> Text.translatableWithFallback(
+                            "commands.thermoo.environment.temperature.player.success",
+                            "The environment temperature change of %s is %s (with a %s chance to dodge)",
+                            target.getDisplayName(),
+                            tempChange,
+                            "%.2f%%".formatted(resistance * 100)
+                    ),
+                    false
+            );
+        } else {
+            source.sendFeedback(
+                    () -> Text.translatableWithFallback(
+                            "commands.thermoo.environment.temperature.player.negative.success",
+                            "The environment temperature change of %s is %s (with a %s chance of doubling)",
+                            target.getDisplayName(),
+                            tempChange,
+                            "%.2f%%".formatted(resistance * -100)
+                    ),
+                    false
+            );
+
+        }
 
         return tempChange;
     }

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/EnvironmentDefinition.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/EnvironmentDefinition.java
@@ -130,6 +130,15 @@ public final class EnvironmentDefinition {
         return this.provider;
     }
 
+    /**
+     * Determines the priority for which this environment should be applied to a biome. Environments wither a HIGHER
+     * priority will be applied FIRST, and environments with a LOWER priority will be applied LAST. Environments with the
+     * same priority may be applied in any order.
+     * <p>
+     * The default priority is {@value DEFAULT_PRIORITY}.
+     *
+     * @return Returns this environment's priority.
+     */
     public int priority() {
         return this.priority;
     }

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/EnvironmentDefinition.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/EnvironmentDefinition.java
@@ -1,14 +1,14 @@
 package com.github.thedeathlycow.thermoo.api.environment;
 
-import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
 import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProvider;
+import com.github.thedeathlycow.thermoo.impl.Thermoo;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.registry.RegistryCodecs;
 import net.minecraft.registry.RegistryKeys;
-import net.minecraft.registry.entry.RegistryElementCodec;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.entry.RegistryEntryList;
+import net.minecraft.util.Identifier;
 import net.minecraft.world.biome.Biome;
 import org.jetbrains.annotations.Contract;
 
@@ -17,6 +17,8 @@ import org.jetbrains.annotations.Contract;
  * in order to work.
  */
 public final class EnvironmentDefinition {
+    public static final Identifier DEFAULT_PHASE = Thermoo.id("default");
+
     public static final Codec<EnvironmentDefinition> CODEC = RecordCodecBuilder.create(
             instance -> instance.group(
                     RegistryCodecs.entryList(RegistryKeys.BIOME)
@@ -27,7 +29,10 @@ public final class EnvironmentDefinition {
                             .forGetter(EnvironmentDefinition::excludeBiomes),
                     EnvironmentProvider.ENTRY_CODEC
                             .fieldOf("provider")
-                            .forGetter(EnvironmentDefinition::provider)
+                            .forGetter(EnvironmentDefinition::provider),
+                    Identifier.CODEC
+                            .optionalFieldOf("phase", DEFAULT_PHASE)
+                            .forGetter(EnvironmentDefinition::phase)
             ).apply(instance, EnvironmentDefinition::new)
     );
 
@@ -37,17 +42,34 @@ public final class EnvironmentDefinition {
 
     private final RegistryEntry<EnvironmentProvider> provider;
 
+    private final Identifier phase;
+
     private EnvironmentDefinition(
             RegistryEntryList<Biome> biomes,
             RegistryEntryList<Biome> excludeBiomes,
-            RegistryEntry<EnvironmentProvider> provider
+            RegistryEntry<EnvironmentProvider> provider,
+            Identifier phase
     ) {
         this.biomes = biomes;
         this.excludeBiomes = excludeBiomes;
         this.provider = provider;
+        this.phase = phase;
     }
 
-    // TODO: replace create methods with a builder (especially when modifiers are added!)
+    public static EnvironmentDefinition.Builder builder(
+            RegistryEntryList<Biome> biomes,
+            RegistryEntry<EnvironmentProvider> provider
+    ) {
+        return new Builder(biomes, RegistryEntryList.empty(), provider);
+    }
+
+    public static EnvironmentDefinition.Builder builder(
+            RegistryEntryList<Biome> biomes,
+            RegistryEntryList<Biome> excludeBiomes,
+            RegistryEntry<EnvironmentProvider> provider
+    ) {
+        return new Builder(biomes, excludeBiomes, provider);
+    }
 
     /**
      * Creates an environment definition
@@ -55,10 +77,12 @@ public final class EnvironmentDefinition {
      * @param biomes   The biomes this definition provides for
      * @param provider The base value provider of this definition
      * @return Returns a new definition
+     * @deprecated Use {@link #builder(RegistryEntryList, RegistryEntry)}
      */
     @Contract("_,_->new")
+    @Deprecated(since = "4.5")
     public static EnvironmentDefinition create(RegistryEntryList<Biome> biomes, RegistryEntry<EnvironmentProvider> provider) {
-        return new EnvironmentDefinition(biomes, RegistryEntryList.empty(), provider);
+        return builder(biomes, provider).build();
     }
 
     /**
@@ -68,14 +92,16 @@ public final class EnvironmentDefinition {
      * @param excludeBiomes The biomes this definition has been blocked from providing for
      * @param provider      The base value provider of this definition
      * @return Returns a new definition
+     * @deprecated Use {@link #builder(RegistryEntryList, RegistryEntryList, RegistryEntry)}
      */
     @Contract("_,_,_->new")
+    @Deprecated(since = "4.5")
     public static EnvironmentDefinition create(
             RegistryEntryList<Biome> biomes,
             RegistryEntryList<Biome> excludeBiomes,
             RegistryEntry<EnvironmentProvider> provider
     ) {
-        return new EnvironmentDefinition(biomes, excludeBiomes, provider);
+        return builder(biomes, excludeBiomes, provider).build();
     }
 
     /**
@@ -112,5 +138,39 @@ public final class EnvironmentDefinition {
      */
     public RegistryEntry<EnvironmentProvider> provider() {
         return this.provider;
+    }
+
+    public Identifier phase() {
+        return this.phase;
+    }
+
+    public static class Builder {
+        private final RegistryEntryList<Biome> biomes;
+
+        private final RegistryEntryList<Biome> excludeBiomes;
+
+        private final RegistryEntry<EnvironmentProvider> provider;
+
+        private Identifier phase = DEFAULT_PHASE;
+
+        private Builder(RegistryEntryList<Biome> biomes, RegistryEntryList<Biome> excludeBiomes, RegistryEntry<EnvironmentProvider> provider) {
+            this.biomes = biomes;
+            this.excludeBiomes = excludeBiomes;
+            this.provider = provider;
+        }
+
+        public Builder withPhase(Identifier phase) {
+            this.phase = phase;
+            return this;
+        }
+
+        public EnvironmentDefinition build() {
+            return new EnvironmentDefinition(
+                    this.biomes,
+                    this.excludeBiomes,
+                    this.provider,
+                    this.phase
+            );
+        }
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/EnvironmentDefinition.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/EnvironmentDefinition.java
@@ -1,14 +1,12 @@
 package com.github.thedeathlycow.thermoo.api.environment;
 
 import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProvider;
-import com.github.thedeathlycow.thermoo.impl.Thermoo;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.registry.RegistryCodecs;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.entry.RegistryEntryList;
-import net.minecraft.util.Identifier;
 import net.minecraft.world.biome.Biome;
 import org.jetbrains.annotations.Contract;
 
@@ -17,7 +15,7 @@ import org.jetbrains.annotations.Contract;
  * in order to work.
  */
 public final class EnvironmentDefinition {
-    public static final Identifier DEFAULT_PHASE = Thermoo.id("default");
+    private static final int DEFAULT_PRIORITY = 1000;
 
     public static final Codec<EnvironmentDefinition> CODEC = RecordCodecBuilder.create(
             instance -> instance.group(
@@ -30,9 +28,9 @@ public final class EnvironmentDefinition {
                     EnvironmentProvider.ENTRY_CODEC
                             .fieldOf("provider")
                             .forGetter(EnvironmentDefinition::provider),
-                    Identifier.CODEC
-                            .optionalFieldOf("phase", DEFAULT_PHASE)
-                            .forGetter(EnvironmentDefinition::phase)
+                    Codec.INT
+                            .optionalFieldOf("priority", DEFAULT_PRIORITY)
+                            .forGetter(EnvironmentDefinition::priority)
             ).apply(instance, EnvironmentDefinition::new)
     );
 
@@ -42,33 +40,25 @@ public final class EnvironmentDefinition {
 
     private final RegistryEntry<EnvironmentProvider> provider;
 
-    private final Identifier phase;
+    private final int priority;
 
     private EnvironmentDefinition(
             RegistryEntryList<Biome> biomes,
             RegistryEntryList<Biome> excludeBiomes,
             RegistryEntry<EnvironmentProvider> provider,
-            Identifier phase
+            int priority
     ) {
         this.biomes = biomes;
         this.excludeBiomes = excludeBiomes;
         this.provider = provider;
-        this.phase = phase;
+        this.priority = priority;
     }
 
     public static EnvironmentDefinition.Builder builder(
             RegistryEntryList<Biome> biomes,
             RegistryEntry<EnvironmentProvider> provider
     ) {
-        return new Builder(biomes, RegistryEntryList.empty(), provider);
-    }
-
-    public static EnvironmentDefinition.Builder builder(
-            RegistryEntryList<Biome> biomes,
-            RegistryEntryList<Biome> excludeBiomes,
-            RegistryEntry<EnvironmentProvider> provider
-    ) {
-        return new Builder(biomes, excludeBiomes, provider);
+        return new Builder(biomes, provider);
     }
 
     /**
@@ -92,7 +82,7 @@ public final class EnvironmentDefinition {
      * @param excludeBiomes The biomes this definition has been blocked from providing for
      * @param provider      The base value provider of this definition
      * @return Returns a new definition
-     * @deprecated Use {@link #builder(RegistryEntryList, RegistryEntryList, RegistryEntry)}
+     * @deprecated Use {@link #builder(RegistryEntryList, RegistryEntry)}
      */
     @Contract("_,_,_->new")
     @Deprecated(since = "4.5")
@@ -101,7 +91,7 @@ public final class EnvironmentDefinition {
             RegistryEntryList<Biome> excludeBiomes,
             RegistryEntry<EnvironmentProvider> provider
     ) {
-        return builder(biomes, excludeBiomes, provider).build();
+        return builder(biomes, provider).excludeBiomes(excludeBiomes).build();
     }
 
     /**
@@ -140,27 +130,28 @@ public final class EnvironmentDefinition {
         return this.provider;
     }
 
-    public Identifier phase() {
-        return this.phase;
+    public int priority() {
+        return this.priority;
     }
 
     public static class Builder {
         private final RegistryEntryList<Biome> biomes;
-
-        private final RegistryEntryList<Biome> excludeBiomes;
-
         private final RegistryEntry<EnvironmentProvider> provider;
+        private RegistryEntryList<Biome> excludeBiomes = RegistryEntryList.empty();
+        private int priority = DEFAULT_PRIORITY;
 
-        private Identifier phase = DEFAULT_PHASE;
-
-        private Builder(RegistryEntryList<Biome> biomes, RegistryEntryList<Biome> excludeBiomes, RegistryEntry<EnvironmentProvider> provider) {
+        private Builder(RegistryEntryList<Biome> biomes, RegistryEntry<EnvironmentProvider> provider) {
             this.biomes = biomes;
-            this.excludeBiomes = excludeBiomes;
             this.provider = provider;
         }
 
-        public Builder withPhase(Identifier phase) {
-            this.phase = phase;
+        public Builder excludeBiomes(RegistryEntryList<Biome> biomes) {
+            this.excludeBiomes = biomes;
+            return this;
+        }
+
+        public Builder withPriority(int priority) {
+            this.priority = priority;
             return this;
         }
 
@@ -169,7 +160,7 @@ public final class EnvironmentDefinition {
                     this.biomes,
                     this.excludeBiomes,
                     this.provider,
-                    this.phase
+                    this.priority
             );
         }
     }

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/ModifyEnvironmentProvider.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/ModifyEnvironmentProvider.java
@@ -1,6 +1,7 @@
 package com.github.thedeathlycow.thermoo.api.environment.provider;
 
 import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
+import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.component.ComponentMap;
@@ -13,6 +14,9 @@ import net.minecraft.world.biome.Biome;
 
 /**
  * Applies modifiers to a base environment provider from a tag or list of environment providers
+ * <p>
+ * <strong>Note:</strong> In general, using the {@linkplain EnvironmentDefinition#priority() environment priority} is more
+ * flexible than using this provider type.
  */
 public final class ModifyEnvironmentProvider implements EnvironmentProvider {
     public static final MapCodec<ModifyEnvironmentProvider> CODEC = RecordCodecBuilder.mapCodec(

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/EnvironmentHeatingMode.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/EnvironmentHeatingMode.java
@@ -15,9 +15,13 @@ public final class EnvironmentHeatingMode implements HeatingMode {
                 ? target.thermoo$getEnvironmentColdResistance()
                 : target.thermoo$getEnvironmentHeatResistance();
 
-        return target.thermoo$getRandom().nextDouble() < resistance
-                ? 0
-                : temperatureChange;
+        if (resistance > 0) {
+            return target.thermoo$getRandom().nextDouble() < resistance ? 0 : temperatureChange;
+        } else if (resistance < 0) {
+            return target.thermoo$getRandom().nextDouble() < -resistance ? 2 * temperatureChange : temperatureChange;
+        } else {
+            return temperatureChange;
+        }
     }
 
     private EnvironmentHeatingMode() {

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/EnvironmentLookupImpl.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/EnvironmentLookupImpl.java
@@ -7,23 +7,21 @@ import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProv
 import com.github.thedeathlycow.thermoo.impl.Thermoo;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.minecraft.component.ComponentMap;
-import net.minecraft.registry.DynamicRegistryManager;
-import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 
-import java.util.*;
+import java.util.List;
 
 public class EnvironmentLookupImpl implements EnvironmentLookup {
     public static final EnvironmentLookupImpl INSTANCE = new EnvironmentLookupImpl();
 
-    private final Map<RegistryKey<Biome>, List<RegistryEntry<EnvironmentProvider>>> biomeProviderCache = new IdentityHashMap<>();
-
     public static void initialize() {
-        ServerLifecycleEvents.SERVER_STOPPED.register(server -> INSTANCE.clearCache());
-        ServerLifecycleEvents.START_DATA_PACK_RELOAD.register((server, resourceManager) -> INSTANCE.clearCache());
+        ServerLifecycleEvents.SERVER_STARTED.register(INSTANCE::addProvidersToBiomes);
     }
 
     @Override
@@ -34,44 +32,37 @@ public class EnvironmentLookupImpl implements EnvironmentLookup {
 
     public ComponentMap findEnvironmentComponentsForBiome(World world, BlockPos pos, RegistryEntry<Biome> biome) {
         ComponentMap.Builder builder = ComponentMap.builder();
-        for (RegistryEntry<EnvironmentProvider> provider : this.getProviders(biome, world.getRegistryManager())) {
-            provider.value().buildCurrentComponents(world, pos, biome, builder);
+        for (EnvironmentProvider provider : this.getProviders(biome)) {
+            provider.buildCurrentComponents(world, pos, biome, builder);
         }
         return builder.build();
     }
 
-    private List<RegistryEntry<EnvironmentProvider>> getProviders(RegistryEntry<Biome> biome, DynamicRegistryManager manager) {
-        RegistryKey<Biome> key = biome.getKey().orElse(null);
-        if (key == null) {
-            return Collections.emptyList();
-        }
-
-        return this.biomeProviderCache.computeIfAbsent(
-                key,
-                k -> {
-                    List<RegistryEntry<EnvironmentProvider>> providers = manager.get(ThermooRegistryKeys.ENVIRONMENT)
-                            .stream()
-                            .filter(definition -> definition.providesFor(biome))
-                            .map(EnvironmentDefinition::provider)
-                            .toList();
-                    if (Thermoo.LOGGER.isDebugEnabled()) {
-                        Thermoo.LOGGER.debug(
-                                "Environment providers found for {}: {}",
-                                k,
-                                providers.stream()
-                                        .map(RegistryEntry::getKey)
-                                        .filter(Optional::isPresent)
-                                        .map(ek -> ek.orElseThrow().getValue())
-                                        .toList()
-                        );
-                    }
-                    return providers;
-                }
-        );
+    private List<EnvironmentProvider> getProviders(RegistryEntry<Biome> biomeEntry) {
+        Biome biome = biomeEntry.value();
+        return ((ThermooBiome) (Object) biome).thermoo$getEnvironmentProviders();
     }
 
-    private void clearCache() {
-        this.biomeProviderCache.clear();
-        Thermoo.LOGGER.debug("Environment lookup cache cleared");
+    private void addProvidersToBiomes(MinecraftServer server) {
+        Registry<EnvironmentDefinition> envRegistry = server.getRegistryManager().get(ThermooRegistryKeys.ENVIRONMENT);
+        Registry<Biome> biomeRegistry = server.getRegistryManager().get(RegistryKeys.BIOME);
+
+        biomeRegistry.streamEntries().forEach(entry -> {
+            List<EnvironmentProvider> providers = this.getAllMatchingProviders(entry, envRegistry);
+
+            ThermooBiome extendedBiome = ((ThermooBiome) (Object) entry.value());
+            extendedBiome.thermoo$replaceProviders(providers);
+
+            if (Thermoo.LOGGER.isDebugEnabled()) {
+                Thermoo.LOGGER.debug("Found {} providers for {}.", providers.size(), entry.registryKey().getValue());
+            }
+        });
+    }
+
+    private List<EnvironmentProvider> getAllMatchingProviders(RegistryEntry<Biome> biome, Registry<EnvironmentDefinition> envRegistry) {
+        return envRegistry.stream()
+                .filter(entry -> entry.providesFor(biome))
+                .map(env -> env.provider().value())
+                .toList();
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/EnvironmentLookupImpl.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/EnvironmentLookupImpl.java
@@ -14,8 +14,12 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import org.jetbrains.annotations.VisibleForTesting;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 public class EnvironmentLookupImpl implements EnvironmentLookup {
     public static final EnvironmentLookupImpl INSTANCE = new EnvironmentLookupImpl();
@@ -32,13 +36,13 @@ public class EnvironmentLookupImpl implements EnvironmentLookup {
 
     public ComponentMap findEnvironmentComponentsForBiome(World world, BlockPos pos, RegistryEntry<Biome> biome) {
         ComponentMap.Builder builder = ComponentMap.builder();
-        for (EnvironmentProvider provider : this.getProviders(biome)) {
-            provider.buildCurrentComponents(world, pos, biome, builder);
+        for (RegistryEntry<EnvironmentProvider> provider : this.getProviders(biome)) {
+            provider.value().buildCurrentComponents(world, pos, biome, builder);
         }
         return builder.build();
     }
 
-    private List<EnvironmentProvider> getProviders(RegistryEntry<Biome> biomeEntry) {
+    private List<RegistryEntry<EnvironmentProvider>> getProviders(RegistryEntry<Biome> biomeEntry) {
         Biome biome = biomeEntry.value();
         return ((ThermooBiome) (Object) biome).thermoo$getEnvironmentProviders();
     }
@@ -48,9 +52,13 @@ public class EnvironmentLookupImpl implements EnvironmentLookup {
         Registry<Biome> biomeRegistry = server.getRegistryManager().get(RegistryKeys.BIOME);
 
         biomeRegistry.streamEntries().forEach(entry -> {
-            List<EnvironmentProvider> providers = this.getAllMatchingProviders(entry, envRegistry);
+            List<RegistryEntry<EnvironmentProvider>> providers = getAllMatchingEnvironments(entry, envRegistry)
+                    .map(EnvironmentDefinition::provider)
+                    .toList();
 
-            ThermooBiome extendedBiome = ((ThermooBiome) (Object) entry.value());
+            Biome biome = entry.value();
+            Objects.requireNonNull(biome);
+            ThermooBiome extendedBiome = ((ThermooBiome) (Object) biome);
             extendedBiome.thermoo$replaceProviders(providers);
 
             if (Thermoo.LOGGER.isDebugEnabled()) {
@@ -59,10 +67,10 @@ public class EnvironmentLookupImpl implements EnvironmentLookup {
         });
     }
 
-    private List<EnvironmentProvider> getAllMatchingProviders(RegistryEntry<Biome> biome, Registry<EnvironmentDefinition> envRegistry) {
+    @VisibleForTesting
+    public static Stream<EnvironmentDefinition> getAllMatchingEnvironments(RegistryEntry<Biome> biome, Registry<EnvironmentDefinition> envRegistry) {
         return envRegistry.stream()
                 .filter(entry -> entry.providesFor(biome))
-                .map(env -> env.provider().value())
-                .toList();
+                .sorted(Comparator.comparingInt(EnvironmentDefinition::priority).reversed());
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/ThermooBiome.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/ThermooBiome.java
@@ -1,13 +1,12 @@
 package com.github.thedeathlycow.thermoo.impl.environment;
 
-import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
+import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProvider;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface ThermooBiome {
-    List<EnvironmentDefinition> thermoo$getEnvironments();
+    List<EnvironmentProvider> thermoo$getEnvironmentProviders();
 
-    void thermoo$addEnvironment(EnvironmentDefinition environment);
-
-    void thermoo$clearEnvironments();
+    void thermoo$replaceProviders(Collection<EnvironmentProvider> providers);
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/ThermooBiome.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/ThermooBiome.java
@@ -1,12 +1,13 @@
 package com.github.thedeathlycow.thermoo.impl.environment;
 
 import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProvider;
+import net.minecraft.registry.entry.RegistryEntry;
 
 import java.util.Collection;
 import java.util.List;
 
 public interface ThermooBiome {
-    List<EnvironmentProvider> thermoo$getEnvironmentProviders();
+    List<RegistryEntry<EnvironmentProvider>> thermoo$getEnvironmentProviders();
 
-    void thermoo$replaceProviders(Collection<EnvironmentProvider> providers);
+    void thermoo$replaceProviders(Collection<RegistryEntry<EnvironmentProvider>> providers);
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/ThermooBiome.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/ThermooBiome.java
@@ -1,0 +1,13 @@
+package com.github.thedeathlycow.thermoo.impl.environment;
+
+import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
+
+import java.util.List;
+
+public interface ThermooBiome {
+    List<EnvironmentDefinition> thermoo$getEnvironments();
+
+    void thermoo$addEnvironment(EnvironmentDefinition environment);
+
+    void thermoo$clearEnvironments();
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/common/BiomeMixin.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/common/BiomeMixin.java
@@ -1,0 +1,34 @@
+package com.github.thedeathlycow.thermoo.mixin.common;
+
+import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
+import com.github.thedeathlycow.thermoo.impl.environment.ThermooBiome;
+import net.minecraft.world.biome.Biome;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Mixin(Biome.class)
+public class BiomeMixin implements ThermooBiome {
+    @Unique
+    private final List<EnvironmentDefinition> thermoo$environments = new ArrayList<>();
+
+    @Override
+    @Unique
+    public List<EnvironmentDefinition> thermoo$getEnvironments() {
+        return this.thermoo$environments;
+    }
+
+    @Override
+    @Unique
+    public void thermoo$addEnvironment(EnvironmentDefinition environment) {
+        this.thermoo$environments.add(environment);
+    }
+
+    @Override
+    @Unique
+    public void thermoo$clearEnvironments() {
+        this.thermoo$environments.clear();
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/common/BiomeMixin.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/common/BiomeMixin.java
@@ -2,6 +2,7 @@ package com.github.thedeathlycow.thermoo.mixin.common;
 
 import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProvider;
 import com.github.thedeathlycow.thermoo.impl.environment.ThermooBiome;
+import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.world.biome.Biome;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -13,16 +14,16 @@ import java.util.List;
 @Mixin(Biome.class)
 public class BiomeMixin implements ThermooBiome {
     @Unique
-    private final List<EnvironmentProvider> thermoo$environments = new ArrayList<>();
+    private final List<RegistryEntry<EnvironmentProvider>> thermoo$environments = new ArrayList<>();
 
     @Override
     @Unique
-    public List<EnvironmentProvider> thermoo$getEnvironmentProviders() {
+    public List<RegistryEntry<EnvironmentProvider>> thermoo$getEnvironmentProviders() {
         return this.thermoo$environments;
     }
 
     @Override
-    public void thermoo$replaceProviders(Collection<EnvironmentProvider> providers) {
+    public void thermoo$replaceProviders(Collection<RegistryEntry<EnvironmentProvider>> providers) {
         this.thermoo$environments.clear();
         this.thermoo$environments.addAll(providers);
     }

--- a/src/main/java/com/github/thedeathlycow/thermoo/mixin/common/BiomeMixin.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/mixin/common/BiomeMixin.java
@@ -1,34 +1,29 @@
 package com.github.thedeathlycow.thermoo.mixin.common;
 
-import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
+import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProvider;
 import com.github.thedeathlycow.thermoo.impl.environment.ThermooBiome;
 import net.minecraft.world.biome.Biome;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(Biome.class)
 public class BiomeMixin implements ThermooBiome {
     @Unique
-    private final List<EnvironmentDefinition> thermoo$environments = new ArrayList<>();
+    private final List<EnvironmentProvider> thermoo$environments = new ArrayList<>();
 
     @Override
     @Unique
-    public List<EnvironmentDefinition> thermoo$getEnvironments() {
+    public List<EnvironmentProvider> thermoo$getEnvironmentProviders() {
         return this.thermoo$environments;
     }
 
     @Override
-    @Unique
-    public void thermoo$addEnvironment(EnvironmentDefinition environment) {
-        this.thermoo$environments.add(environment);
-    }
-
-    @Override
-    @Unique
-    public void thermoo$clearEnvironments() {
+    public void thermoo$replaceProviders(Collection<EnvironmentProvider> providers) {
         this.thermoo$environments.clear();
+        this.thermoo$environments.addAll(providers);
     }
 }

--- a/src/main/resources/assets/thermoo/lang/en_us.json
+++ b/src/main/resources/assets/thermoo/lang/en_us.json
@@ -31,6 +31,7 @@
     "commands.thermoo.environment.temperature.success": "The environmental temperature at %s, %s, %s (%s) is %s°%s",
     "commands.thermoo.environment.humidity.success": "The environmental relative humidity at %s, %s, %s (%s) is %s%%",
     "commands.thermoo.environment.temperature.player.success": "The environment temperature change of %s is %s (with a %s chance to dodge)",
+    "commands.thermoo.environment.temperature.player.negative.success": "The environment temperature change of %s is %s (with a %s chance of doubling)",
     
     
     "commands.thermoo.soaking.get.current.success": "The current soaking value of %s is %d",

--- a/src/main/resources/thermoo.mixins.json
+++ b/src/main/resources/thermoo.mixins.json
@@ -5,14 +5,15 @@
     "compatibilityLevel": "JAVA_21",
     "mixins": [
         "ArmorItemMixin",
-        "accessor.ComponentMapBuilderAccessor",
+        "BiomeMixin",
         "EnvironmentAwareEntityMixin",
         "HotFloorMixin",
         "ItemStackMixin",
         "LivingEntityAttributeMixin",
         "LivingEntityEnvironmentTickMixin",
         "PlayerTemperatureTickMixin",
-        "accessor.AttributeModifiersComponentBuilderAccessor"
+        "accessor.AttributeModifiersComponentBuilderAccessor",
+        "accessor.ComponentMapBuilderAccessor"
     ],
     "injectors": {
         "defaultRequire": 1

--- a/src/testmod/java/com/github/thedeathlycow/thermoo/testmod/tests/environment/EnvironmentPriorityTests.java
+++ b/src/testmod/java/com/github/thedeathlycow/thermoo/testmod/tests/environment/EnvironmentPriorityTests.java
@@ -1,0 +1,45 @@
+package com.github.thedeathlycow.thermoo.testmod.tests.environment;
+
+import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
+import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
+import com.github.thedeathlycow.thermoo.impl.environment.EnvironmentLookupImpl;
+import com.github.thedeathlycow.thermoo.testmod.ThermooTestMod;
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.test.GameTest;
+import net.minecraft.test.GameTestException;
+import net.minecraft.test.TestContext;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.BiomeKeys;
+
+import java.util.List;
+
+@SuppressWarnings("unused")
+public class EnvironmentPriorityTests {
+    @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+    public void environments_loaded_in_priority_order(TestContext context) {
+        ServerWorld world = context.getWorld();
+        Registry<EnvironmentDefinition> registry = world.getRegistryManager().get(ThermooRegistryKeys.ENVIRONMENT);
+        RegistryEntry<Biome> netherWastes = world.getRegistryManager()
+                .get(RegistryKeys.BIOME)
+                .getEntry(BiomeKeys.NETHER_WASTES)
+                .orElseThrow(() -> new GameTestException("Missing nether wastes biome!"));
+
+        List<Identifier> loadedEnvironments = EnvironmentLookupImpl.getAllMatchingEnvironments(netherWastes, registry)
+                .map(registry::getId)
+                .toList();
+
+        List<Identifier> expectedEnvironments = List.of(
+                ThermooTestMod.id("priority/high_priority"),
+                ThermooTestMod.id("priority/default_priority"),
+                ThermooTestMod.id("priority/low_priority")
+        );
+
+        context.assertEquals(loadedEnvironments, expectedEnvironments, "Nether Wastes Environment Providers");
+        context.complete();
+    }
+}

--- a/src/testmod/resources/data/thermoo-test/thermoo/environment/priority/default_priority.json
+++ b/src/testmod/resources/data/thermoo-test/thermoo/environment/priority/default_priority.json
@@ -1,0 +1,13 @@
+{
+    "biomes": [
+        "minecraft:nether_wastes"
+    ],
+    "priority": 1000,
+    "provider": {
+        "type": "thermoo:constant",
+        "components": {
+            "thermoo:temperature": 35.0,
+            "thermoo:relative_humidity": 0.01
+        }
+    }
+}

--- a/src/testmod/resources/data/thermoo-test/thermoo/environment/priority/high_priority.json
+++ b/src/testmod/resources/data/thermoo-test/thermoo/environment/priority/high_priority.json
@@ -1,0 +1,13 @@
+{
+    "biomes": [
+        "minecraft:nether_wastes"
+    ],
+    "priority": 2000,
+    "provider": {
+        "type": "thermoo:constant",
+        "components": {
+            "thermoo:temperature": 35.0,
+            "thermoo:relative_humidity": 0.01
+        }
+    }
+}

--- a/src/testmod/resources/data/thermoo-test/thermoo/environment/priority/low_priority.json
+++ b/src/testmod/resources/data/thermoo-test/thermoo/environment/priority/low_priority.json
@@ -1,0 +1,13 @@
+{
+    "biomes": [
+        "minecraft:nether_wastes"
+    ],
+    "priority": 0,
+    "provider": {
+        "type": "thermoo:constant",
+        "components": {
+            "thermoo:temperature": 35.0,
+            "thermoo:relative_humidity": 0.01
+        }
+    }
+}

--- a/src/testmod/resources/fabric.mod.json
+++ b/src/testmod/resources/fabric.mod.json
@@ -28,6 +28,7 @@
 			"com.github.thedeathlycow.thermoo.testmod.tests.environment.DesertWetHumidityTests",
 			"com.github.thedeathlycow.thermoo.testmod.tests.environment.PrecipitationTypeTests",
 			"com.github.thedeathlycow.thermoo.testmod.tests.environment.WeatherStateTests",
+			"com.github.thedeathlycow.thermoo.testmod.tests.environment.EnvironmentPriorityTests",
 			"com.github.thedeathlycow.thermoo.testmod.tests.soaking.SoakableTests"
 		]
 	}


### PR DESCRIPTION
Implements a priority field to environment definitions that sets the order for which the environment's provider should be applied to a biome. This is much more flexible than using the `thermoo:modify` environment provider. This also adds providers onto the `Biome` class directly as a mixin field extension, which should make lookup slightly faster.

**Note to self:** The format needs to be updated on the wiki, but the wiki files do not exist on this branch. 