### PR TITLE
[1.21.1] Backport argentine translations

### DIFF
--- a/src/main/resources/assets/thermoo/lang/es_ar.json
+++ b/src/main/resources/assets/thermoo/lang/es_ar.json
@@ -1,11 +1,11 @@
 {
-    "attribute.thermoo.min_temperature": "Temperatura mínima",
-    "attribute.thermoo.max_temperature": "Temperatura máxima",
-    "attribute.thermoo.max_soaking_tick_multiplier": "Multiplicador máximo de empapado",
-    "attribute.thermoo.frost_resistance": "Resistencia al frío",
-    "attribute.thermoo.heat_resistance": "Resistencia al calor",
-    "attribute.thermoo.environment_heat_resistance": "Resistencia al calor ambiental",
-    "attribute.thermoo.environment_frost_resistance": "Resistencia al frío ambiental",
+    "attribute.thermoo.generic.min_temperature": "Temperatura mínima",
+    "attribute.thermoo.generic.max_temperature": "Temperatura máxima",
+    "attribute.thermoo.generic.max_soaking_tick_multiplier": "Multiplicador máximo de empapado",
+    "attribute.thermoo.generic.frost_resistance": "Resistencia al frío",
+    "attribute.thermoo.generic.heat_resistance": "Resistencia al calor",
+    "attribute.thermoo.generic.environment_heat_resistance": "Resistencia al calor ambiental",
+    "attribute.thermoo.generic.environment_frost_resistance": "Resistencia al frío ambiental",
     
     "tag.item.thermoo.consumable.cooling": "Consumibles refrescantes",
     "tag.item.thermoo.consumable.warming": "Consumibles que dan calor",

--- a/src/main/resources/assets/thermoo/lang/es_ar.json
+++ b/src/main/resources/assets/thermoo/lang/es_ar.json
@@ -1,0 +1,37 @@
+{
+    "attribute.thermoo.min_temperature": "Temperatura mínima",
+    "attribute.thermoo.max_temperature": "Temperatura máxima",
+    "attribute.thermoo.max_soaking_tick_multiplier": "Multiplicador máximo de empapado",
+    "attribute.thermoo.frost_resistance": "Resistencia al frío",
+    "attribute.thermoo.heat_resistance": "Resistencia al calor",
+    "attribute.thermoo.environment_heat_resistance": "Resistencia al calor ambiental",
+    "attribute.thermoo.environment_frost_resistance": "Resistencia al frío ambiental",
+    
+    "tag.item.thermoo.consumable.cooling": "Consumibles refrescantes",
+    "tag.item.thermoo.consumable.warming": "Consumibles que dan calor",
+    
+    "commands.thermoo.temperature.exception.not_living_entity": "¡El objetivo no es una entidad viva!",
+    "commands.thermoo.temperature.get.scale.success": "La escala de temperatura de %s es %d",
+    "commands.thermoo.temperature.get.max.success": "%s puede tener una temperatura máxima de %d",
+    "commands.thermoo.temperature.get.min.success": "%s puede tener una temperatura mínima de %d",
+    "commands.thermoo.temperature.get.current.success": "La temperatura actual de %s es %d",
+    "commands.thermoo.temperature.add.success.single": "Se le agregó %d de temperatura a %s (ahora tiene %d)",
+    "commands.thermoo.temperature.add.success.multiple": "Se le agregó %d de temperatura a %d entidades",
+    "commands.thermoo.temperature.remove.success.single": "Se le quitó %d de temperatura a %s (ahora tiene %d)",
+    "commands.thermoo.temperature.remove.success.multiple": "Se le quitó %d de temperatura a %d entidades",
+    "commands.thermoo.temperature.set.success.single": "Se estableció la temperatura de %s en %d",
+    "commands.thermoo.temperature.set.success.multiple": "Se estableció la temperatura de %s entidades en %d",
+
+    "commands.thermoo.environment.temperature.success": "La temperatura ambiental en %s, %s, %s (%s) es de %s°%s",
+    "commands.thermoo.environment.humidity.success": "La humedad relativa ambiental en %s, %s, %s (%s) es de %s%%",
+    "commands.thermoo.environment.temperature.player.success": "El cambio de temperatura ambiental de %s es de %s (con una probabilidad de %s de evitarlo)",
+    "commands.thermoo.environment.temperature.player.negative.success": "El cambio de temperatura ambiental de %s es de %s (con una probabilidad de %s de duplicarse)",
+
+    "commands.thermoo.soaking.get.current.success": "El valor actual de empapado de %s es %d",
+    "commands.thermoo.soaking.get.scale.success": "La escala de empapado actual de %s es %d",
+    "commands.thermoo.soaking.get.min.success": "El valor mínimo de empapado de %s es %d",
+    "commands.thermoo.soaking.get.max.success": "El valor máximo de empapado de %s es %d",
+    "commands.thermoo.soaking.set.success": "Se estableció el valor de empapado de %s en %d (ahora tiene %d)",
+    "commands.thermoo.soaking.add.success": "Se le sumaron %d puntos al valor de empapado de %s (ahora tiene %d)",
+    "commands.thermoo.soaking.remove.success": "Se le restaron %d puntos al valor de empapado de %s (ahora tiene %d)"
+}

--- a/src/main/resources/assets/thermoo/lang/es_mx.json
+++ b/src/main/resources/assets/thermoo/lang/es_mx.json
@@ -1,8 +1,8 @@
 {
-    "attribute.thermoo.min_temperature": "Temperatura Mínima",
-    "attribute.thermoo.max_temperature": "Temperatura Máxima",
-    "attribute.thermoo.frost_resistance": "Resistencia al Congelamiento",
-    "attribute.thermoo.heat_resistance": "Resistencia al Calor",
+    "attribute.thermoo.generic.min_temperature": "Temperatura Mínima",
+    "attribute.thermoo.generic.max_temperature": "Temperatura Máxima",
+    "attribute.thermoo.generic.frost_resistance": "Resistencia al Congelamiento",
+    "attribute.thermoo.generic.heat_resistance": "Resistencia al Calor",
     
     "tag.item.thermoo.consumable.cooling": "Consumibles de Enfriamiento",
     "tag.item.thermoo.consumable.warming": "Consumibles de Calentamiento",


### PR DESCRIPTION
 backport #77 with updated attribute translation keys for both argentine and Mexican Spanish 