### PR TITLE
Thermoo Patches Nag

### DIFF
--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
@@ -4,6 +4,7 @@ import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
 import com.github.thedeathlycow.thermoo.api.command.*;
 import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
 import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProvider;
+import com.github.thedeathlycow.thermoo.impl.compat.ThermooPatchesNag;
 import com.github.thedeathlycow.thermoo.impl.config.ThermooConfig;
 import com.github.thedeathlycow.thermoo.impl.environment.EnvironmentLookupImpl;
 import com.github.thedeathlycow.thermoo.impl.temperature.effect.TemperatureEffectLoader;
@@ -31,6 +32,7 @@ public class Thermoo implements ModInitializer {
     @Override
     public void onInitialize() {
         config = ThermooConfig.initialize();
+        ThermooPatchesNag.initialize(config);
 
         ArgumentTypeRegistry.registerArgumentType(
                 Thermoo.id("heating_mode"),

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
@@ -4,6 +4,7 @@ import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
 import com.github.thedeathlycow.thermoo.api.command.*;
 import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
 import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProvider;
+import com.github.thedeathlycow.thermoo.impl.config.ThermooConfig;
 import com.github.thedeathlycow.thermoo.impl.environment.EnvironmentLookupImpl;
 import com.github.thedeathlycow.thermoo.impl.temperature.effect.TemperatureEffectLoader;
 import net.fabricmc.api.ModInitializer;
@@ -15,17 +16,22 @@ import net.minecraft.command.argument.serialize.ConstantArgumentSerializer;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Thermoo implements ModInitializer {
-
     public static final String MODID = "thermoo";
+
     public static final Logger LOGGER = LoggerFactory.getLogger(MODID);
 
+    @Nullable
+    private static ThermooConfig config = null;
 
     @Override
     public void onInitialize() {
+        config = ThermooConfig.initialize();
+
         ArgumentTypeRegistry.registerArgumentType(
                 Thermoo.id("heating_mode"),
                 HeatingModeArgumentType.class,
@@ -74,5 +80,12 @@ public class Thermoo implements ModInitializer {
     @Contract("_->new")
     public static Identifier id(String path) {
         return Identifier.of(MODID, path);
+    }
+
+    public static ThermooConfig getConfig() {
+        if (config == null) {
+            throw new NullPointerException("Config is not initialized!");
+        }
+        return config;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
@@ -4,7 +4,6 @@ import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
 import com.github.thedeathlycow.thermoo.api.command.*;
 import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
 import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProvider;
-import com.github.thedeathlycow.thermoo.impl.compat.ThermooPatchesNag;
 import com.github.thedeathlycow.thermoo.impl.config.ThermooConfig;
 import com.github.thedeathlycow.thermoo.impl.environment.EnvironmentLookupImpl;
 import com.github.thedeathlycow.thermoo.impl.temperature.effect.TemperatureEffectLoader;
@@ -31,9 +30,6 @@ public class Thermoo implements ModInitializer {
 
     @Override
     public void onInitialize() {
-        config = ThermooConfig.initialize();
-        ThermooPatchesNag.initialize(config);
-
         ArgumentTypeRegistry.registerArgumentType(
                 Thermoo.id("heating_mode"),
                 HeatingModeArgumentType.class,
@@ -86,7 +82,7 @@ public class Thermoo implements ModInitializer {
 
     public static ThermooConfig getConfig() {
         if (config == null) {
-            throw new NullPointerException("Config is not initialized!");
+            config = ThermooConfig.create();
         }
         return config;
     }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooClient.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooClient.java
@@ -1,12 +1,11 @@
 package com.github.thedeathlycow.thermoo.impl;
 
+import com.github.thedeathlycow.thermoo.impl.compat.ThermooPatchesNag;
 import net.fabricmc.api.ClientModInitializer;
 
 public class ThermooClient implements ClientModInitializer {
-
-
     @Override
     public void onInitializeClient() {
-        // empty
+        ThermooPatchesNag.initialize(Thermoo.getConfig());
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchList.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchList.java
@@ -22,8 +22,8 @@ public record PatchList(
             ).apply(instance, PatchList::new)
     );
 
-    public List<ModContainer> getPatchAvailableMods() throws VersionParsingException {
-        Version gameVersion = FabricLoader.getInstance().getModContainer("minecraft")
+    public List<ModContainer> getPatchAvailableMods(FabricLoader loader) throws VersionParsingException {
+        Version gameVersion = loader.getModContainer("minecraft")
                 .orElseThrow()
                 .getMetadata()
                 .getVersion();
@@ -33,16 +33,16 @@ public record PatchList(
         for (PatchedVersion patch : this.patches) {
             VersionPredicate predicate = VersionPredicate.parse(patch.minecraftVersion());
             if (predicate.test(gameVersion)) {
-                this.extendPatchAvailableMods(patchAvailableMods, patch);
+                this.extendPatchAvailableMods(loader, patchAvailableMods, patch);
             }
         }
 
         return patchAvailableMods;
     }
 
-    private void extendPatchAvailableMods(List<ModContainer> patchAvailableMods, PatchedVersion patch) {
+    private void extendPatchAvailableMods(FabricLoader loader, List<ModContainer> patchAvailableMods, PatchedVersion patch) {
         for (String modid : patch.mods()) {
-            FabricLoader.getInstance().getModContainer(modid).ifPresent(patchAvailableMods::add);
+            loader.getModContainer(modid).ifPresent(patchAvailableMods::add);
         }
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchList.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchList.java
@@ -2,7 +2,13 @@ package com.github.thedeathlycow.thermoo.impl.compat;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
+import net.fabricmc.loader.api.metadata.version.VersionPredicate;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public record PatchList(
@@ -15,4 +21,28 @@ public record PatchList(
                             .forGetter(PatchList::patches)
             ).apply(instance, PatchList::new)
     );
+
+    public List<ModContainer> getPatchAvailableMods() throws VersionParsingException {
+        Version gameVersion = FabricLoader.getInstance().getModContainer("minecraft")
+                .orElseThrow()
+                .getMetadata()
+                .getVersion();
+
+        List<ModContainer> patchAvailableMods = new ArrayList<>();
+
+        for (PatchedVersion patch : this.patches) {
+            VersionPredicate predicate = VersionPredicate.parse(patch.minecraftVersion());
+            if (predicate.test(gameVersion)) {
+                this.extendPatchAvailableMods(patchAvailableMods, patch);
+            }
+        }
+
+        return patchAvailableMods;
+    }
+
+    private void extendPatchAvailableMods(List<ModContainer> patchAvailableMods, PatchedVersion patch) {
+        for (String modid : patch.mods()) {
+            FabricLoader.getInstance().getModContainer(modid).ifPresent(patchAvailableMods::add);
+        }
+    }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchList.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchList.java
@@ -1,0 +1,18 @@
+package com.github.thedeathlycow.thermoo.impl.compat;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import java.util.List;
+
+public record PatchList(
+        List<PatchedVersion> patches
+) {
+    public static final Codec<PatchList> CODEC = RecordCodecBuilder.create(
+            instance -> instance.group(
+                    PatchedVersion.CODEC.listOf()
+                            .fieldOf("patches")
+                            .forGetter(PatchList::patches)
+            ).apply(instance, PatchList::new)
+    );
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListService.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListService.java
@@ -23,7 +23,7 @@ public final class PatchListService {
      * @throws InterruptedException Thrown if the client is interrupted
      * @throws IOException          Thrown if I/O error occurs while sending/receiving data, or if the response is not OK.
      */
-    public static PatchList fetchPatches(HttpClient client, URI uri) throws InterruptedException, IOException {
+    public static PatchList fetchPatchList(HttpClient client, URI uri) throws InterruptedException, IOException {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(uri)
                 .GET()

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListService.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListService.java
@@ -20,13 +20,14 @@ public final class PatchListService {
      * (such as on a virtual thread).
      *
      * @param client An active HTTP client
+     * @param uri The URI of the location of the patch list
      * @return Returns the decoded patch list from the URI
      * @throws InterruptedException Thrown if the client is interrupted
      * @throws IOException          Thrown if I/O error occurs while sending/receiving data, or if the response is not OK.
      */
-    public static PatchList fetchPatches(HttpClient client) throws InterruptedException, IOException {
+    public static PatchList fetchPatches(HttpClient client, URI uri) throws InterruptedException, IOException {
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(GIST_URL))
+                .uri(uri)
                 .GET()
                 .build();
 
@@ -44,6 +45,6 @@ public final class PatchListService {
     }
 
     private PatchListService() {
-        
+
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListService.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListService.java
@@ -13,8 +13,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 public final class PatchListService {
-    private static final String GIST_URL = "https://gist.githubusercontent.com/TheDeathlyCow/1164d3721101f0540d455cc9f63fcac8/raw/74f939ed1a89a0e603891affd3bd9e2d8dc75c8b/thermoo-patches-patch-list.json";
-
     /**
      * Fetches the Thermoo Patches patch list from the given URI. This call is blocking and should be executed asynchronously
      * (such as on a virtual thread).

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListService.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListService.java
@@ -1,0 +1,49 @@
+package com.github.thedeathlycow.thermoo.impl.compat;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.JsonOps;
+import net.minecraft.util.JsonHelper;
+import org.apache.http.client.HttpResponseException;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public final class PatchListService {
+    private static final String GIST_URL = "https://gist.githubusercontent.com/TheDeathlyCow/1164d3721101f0540d455cc9f63fcac8/raw/74f939ed1a89a0e603891affd3bd9e2d8dc75c8b/thermoo-patches-patch-list.json";
+
+    /**
+     * Fetches the Thermoo Patches patch list from the given URI. This call is blocking and should be executed asynchronously
+     * (such as on a virtual thread).
+     *
+     * @param client An active HTTP client
+     * @return Returns the decoded patch list from the URI
+     * @throws InterruptedException Thrown if the client is interrupted
+     * @throws IOException          Thrown if I/O error occurs while sending/receiving data, or if the response is not OK.
+     */
+    public static PatchList fetchPatches(HttpClient client) throws InterruptedException, IOException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(GIST_URL))
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != HttpURLConnection.HTTP_OK) {
+            throw new HttpResponseException(response.statusCode(), response.body());
+        }
+
+        JsonObject json = JsonHelper.deserialize(response.body());
+        return PatchList.CODEC.parse(
+                JsonOps.INSTANCE,
+                json
+        ).getOrThrow();
+    }
+
+    private PatchListService() {
+        
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchedVersion.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/PatchedVersion.java
@@ -1,0 +1,22 @@
+package com.github.thedeathlycow.thermoo.impl.compat;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import java.util.List;
+
+public record PatchedVersion(
+        String minecraftVersion,
+        List<String> mods
+) {
+    public static final Codec<PatchedVersion> CODEC = RecordCodecBuilder.create(
+            instance -> instance.group(
+                    Codec.STRING
+                            .fieldOf("minecraft_version")
+                            .forGetter(PatchedVersion::minecraftVersion),
+                    Codec.STRING.listOf()
+                            .fieldOf("mods")
+                            .forGetter(PatchedVersion::mods)
+            ).apply(instance, PatchedVersion::new)
+    );
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/ThermooPatchesNag.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/ThermooPatchesNag.java
@@ -2,21 +2,19 @@ package com.github.thedeathlycow.thermoo.impl.compat;
 
 import com.github.thedeathlycow.thermoo.impl.Thermoo;
 import com.github.thedeathlycow.thermoo.impl.config.ThermooConfig;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
-import net.fabricmc.fabric.api.networking.v1.PacketSender;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.VersionParsingException;
 import net.fabricmc.loader.api.metadata.ModMetadata;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.network.ServerPlayNetworkHandler;
-import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,16 +22,11 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
-public class ThermooPatchesNag implements ServerPlayConnectionEvents.Join, ServerTickEvents.EndTick {
+public class ThermooPatchesNag implements ClientTickEvents.EndTick {
     private static final Logger LOGGER = LoggerFactory.getLogger(Thermoo.MODID + "-patch-nag");
-
-    private static final Style HEADER_STYLE = Style.EMPTY
-            .withBold(true)
-            .withColor(Formatting.YELLOW);
 
     private static final Style LINK_STYLE = Style.EMPTY
             .withUnderline(true)
@@ -42,15 +35,17 @@ public class ThermooPatchesNag implements ServerPlayConnectionEvents.Join, Serve
 
     private static final ThermooPatchesNag INSTANCE = new ThermooPatchesNag();
 
-    private final AtomicReference<Text> nagMessage = new AtomicReference<>(null);
+    private final List<ModContainer> patchAvailableMods = Collections.synchronizedList(new ArrayList<>());
 
-    private final List<ServerPlayerEntity> playersToBroadcast = new ArrayList<>();
+    private boolean naggedPlayer = false;
+
+    @Nullable
+    private Text nagMessage = null;
 
     public static void initialize(ThermooConfig config) {
         if (enableNag(config)) {
-            INSTANCE.queueFetch(config);
-            ServerPlayConnectionEvents.JOIN.register(INSTANCE);
-            ServerTickEvents.END_SERVER_TICK.register(INSTANCE);
+            INSTANCE.fetchAsync(config);
+            ClientTickEvents.END_CLIENT_TICK.register(INSTANCE);
         }
     }
 
@@ -59,28 +54,22 @@ public class ThermooPatchesNag implements ServerPlayConnectionEvents.Join, Serve
     }
 
     @Override
-    public void onPlayReady(ServerPlayNetworkHandler handler, PacketSender sender, MinecraftServer server) {
-        if (server.isSingleplayer() || handler.getPlayer().getPermissionLevel() >= server.getOpPermissionLevel()) {
-            this.playersToBroadcast.add(handler.getPlayer());
+    public void onEndTick(MinecraftClient client) {
+        if (this.naggedPlayer) {
+            return;
+        }
+
+        Text nagMessageText = this.getNagMessage();
+        ClientPlayerEntity player = client.player;
+
+        if (nagMessageText != null && player != null) {
+            this.naggedPlayer = true;
+            player.sendMessage(nagMessageText, false);
+            LOGGER.warn(nagMessageText.getString());
         }
     }
 
-    @Override
-    public void onEndTick(MinecraftServer server) {
-        if (!this.playersToBroadcast.isEmpty() && this.nagMessage.get() != null) {
-            Iterator<ServerPlayerEntity> players = this.playersToBroadcast.iterator();
-            while (players.hasNext()) {
-                ServerPlayerEntity player = players.next();
-                player.sendMessage(this.nagMessage.get());
-                players.remove();
-
-                // also nag the server for good measure
-                LOGGER.warn(this.nagMessage.get().getString());
-            }
-        }
-    }
-
-    private void queueFetch(ThermooConfig config) {
+    private void fetchAsync(ThermooConfig config) {
         Thread.ofVirtual().start(() -> {
             try {
                 this.fetch(config);
@@ -91,11 +80,12 @@ public class ThermooPatchesNag implements ServerPlayConnectionEvents.Join, Serve
     }
 
     private void fetch(ThermooConfig config) {
+        LOGGER.info("Fetching Thermoo Patches patch list data...");
         List<ModContainer> patchAvailableMods;
 
         try (HttpClient client = HttpClient.newHttpClient()) {
             PatchList patches = PatchListService.fetchPatchList(client, config.thermooPatchesPatchListUrl());
-            patchAvailableMods = patches.getPatchAvailableMods();
+            patchAvailableMods = patches.getPatchAvailableMods(FabricLoader.getInstance());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
@@ -105,30 +95,41 @@ public class ThermooPatchesNag implements ServerPlayConnectionEvents.Join, Serve
 
         if (!patchAvailableMods.isEmpty()) {
             LOGGER.warn("Thermoo Patches is recommended for this mod set!");
-            this.nagMessage.set(this.createNagMessage(patchAvailableMods));
+            this.patchAvailableMods.addAll(patchAvailableMods);
         } else if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Your mod set is patched with Thermoo Patches, great job!");
         }
     }
 
-    private Text createNagMessage(List<ModContainer> patchAvailableMods) {
+    @Nullable
+    private Text getNagMessage() {
+        if (!this.patchAvailableMods.isEmpty()) {
+            this.nagMessage = this.createNagMessage();
+        }
+
+        return this.nagMessage;
+    }
+
+    private Text createNagMessage() {
         MutableText message = Text.literal("").formatted(Formatting.DARK_GREEN);
 
         message.append("\n");
         message.append(Text.translatable("text.thermoo.thermoo-patches-nag.body"));
         message.append("\n\n");
 
-        patchAvailableMods.forEach(mod -> {
-            ModMetadata metadata = mod.getMetadata();
-            Text modEntry = Text.translatable(
-                    "text.thermoo.thermoo-patches-nag.item",
-                    metadata.getName(),
-                    metadata.getId()
-            ).formatted(Formatting.YELLOW);
+        synchronized (this.patchAvailableMods) {
+            patchAvailableMods.forEach(mod -> {
+                ModMetadata metadata = mod.getMetadata();
+                Text modEntry = Text.translatable(
+                        "text.thermoo.thermoo-patches-nag.item",
+                        metadata.getName(),
+                        metadata.getId()
+                ).formatted(Formatting.YELLOW);
 
-            message.append(modEntry);
-            message.append("\n");
-        });
+                message.append(modEntry);
+                message.append("\n");
+            });
+        }
 
         message.append("\n");
         message.append(Text.translatable("text.thermoo.thermoo-patches-nag.footer"));

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/ThermooPatchesNag.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/ThermooPatchesNag.java
@@ -12,23 +12,33 @@ import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.ClickEvent;
 import net.minecraft.text.MutableText;
+import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.TriState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ThermooPatchesNag implements ServerPlayConnectionEvents.Join, ServerTickEvents.EndTick {
     private static final Logger LOGGER = LoggerFactory.getLogger(Thermoo.MODID + "-patch-nag");
+
+    private static final Style HEADER_STYLE = Style.EMPTY
+            .withBold(true)
+            .withColor(Formatting.YELLOW);
+
+    private static final Style LINK_STYLE = Style.EMPTY
+            .withUnderline(true)
+            .withColor(Formatting.GREEN)
+            .withClickEvent(new ClickEvent.OpenUrl(URI.create("https://www.modrinth.com/mod/thermoo-patches")));
 
     private static final ThermooPatchesNag INSTANCE = new ThermooPatchesNag();
 
@@ -102,8 +112,13 @@ public class ThermooPatchesNag implements ServerPlayConnectionEvents.Join, Serve
     }
 
     private Text createNagMessage(List<ModContainer> patchAvailableMods) {
-        MutableText message = Text.translatable("text.thermoo.thermoo-patches-nag.header").formatted(Formatting.BLUE);
+        MutableText message = Text.literal("").formatted(Formatting.DARK_GREEN);
+
+        message.append(Text.translatable("text.thermoo.thermoo-patches-nag.header").setStyle(HEADER_STYLE));
+
         message.append("\n");
+        message.append(Text.translatable("text.thermoo.thermoo-patches-nag.body"));
+        message.append("\n\n");
 
         patchAvailableMods.forEach(mod -> {
             ModMetadata metadata = mod.getMetadata();
@@ -111,13 +126,19 @@ public class ThermooPatchesNag implements ServerPlayConnectionEvents.Join, Serve
                     "text.thermoo.thermoo-patches-nag.item",
                     metadata.getName(),
                     metadata.getId()
-            ).formatted(Formatting.GOLD);
+            ).formatted(Formatting.YELLOW);
 
             message.append(modEntry);
             message.append("\n");
         });
 
+        message.append("\n");
         message.append(Text.translatable("text.thermoo.thermoo-patches-nag.footer"));
+        message.append(
+                Text.literal("\nhttps://www.modrinth.com/mod/thermoo-patches\n")
+                        .setStyle(LINK_STYLE)
+        );
+        message.append(Text.translatable("text.thermoo.thermoo-patches-nag.disable"));
 
         return message;
     }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/ThermooPatchesNag.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/ThermooPatchesNag.java
@@ -114,8 +114,6 @@ public class ThermooPatchesNag implements ServerPlayConnectionEvents.Join, Serve
     private Text createNagMessage(List<ModContainer> patchAvailableMods) {
         MutableText message = Text.literal("").formatted(Formatting.DARK_GREEN);
 
-        message.append(Text.translatable("text.thermoo.thermoo-patches-nag.header").setStyle(HEADER_STYLE));
-
         message.append("\n");
         message.append(Text.translatable("text.thermoo.thermoo-patches-nag.body"));
         message.append("\n\n");
@@ -135,7 +133,7 @@ public class ThermooPatchesNag implements ServerPlayConnectionEvents.Join, Serve
         message.append("\n");
         message.append(Text.translatable("text.thermoo.thermoo-patches-nag.footer"));
         message.append(
-                Text.literal("\nhttps://www.modrinth.com/mod/thermoo-patches\n")
+                Text.literal("\nhttps://www.modrinth.com/mod/thermoo-patches\n\n")
                         .setStyle(LINK_STYLE)
         );
         message.append(Text.translatable("text.thermoo.thermoo-patches-nag.disable"));

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/ThermooPatchesNag.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/compat/ThermooPatchesNag.java
@@ -1,0 +1,128 @@
+package com.github.thedeathlycow.thermoo.impl.compat;
+
+import com.github.thedeathlycow.thermoo.impl.Thermoo;
+import com.github.thedeathlycow.thermoo.impl.config.ThermooConfig;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.VersionParsingException;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.TriState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ThermooPatchesNag implements ServerPlayConnectionEvents.Join, ServerTickEvents.EndTick {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Thermoo.MODID + "-patch-nag");
+
+    private static final ThermooPatchesNag INSTANCE = new ThermooPatchesNag();
+
+    private final AtomicReference<Text> nagMessage = new AtomicReference<>(null);
+
+    private final List<ServerPlayerEntity> playersToBroadcast = new ArrayList<>();
+
+    public static void initialize(ThermooConfig config) {
+        if (enableNag(config)) {
+            INSTANCE.queueFetch(config);
+            ServerPlayConnectionEvents.JOIN.register(INSTANCE);
+            ServerTickEvents.END_SERVER_TICK.register(INSTANCE);
+        }
+    }
+
+    private static boolean enableNag(ThermooConfig config) {
+        return !FabricLoader.getInstance().isModLoaded("thermoo-patches") && config.enableThermooPatchesNag();
+    }
+
+    @Override
+    public void onPlayReady(ServerPlayNetworkHandler handler, PacketSender sender, MinecraftServer server) {
+        if (server.isSingleplayer() || handler.getPlayer().getPermissionLevel() >= server.getOpPermissionLevel()) {
+            this.playersToBroadcast.add(handler.getPlayer());
+        }
+    }
+
+    @Override
+    public void onEndTick(MinecraftServer server) {
+        if (!this.playersToBroadcast.isEmpty() && this.nagMessage.get() != null) {
+            Iterator<ServerPlayerEntity> players = this.playersToBroadcast.iterator();
+            while (players.hasNext()) {
+                ServerPlayerEntity player = players.next();
+                player.sendMessage(this.nagMessage.get());
+                players.remove();
+
+                // also nag the server for good measure
+                LOGGER.warn(this.nagMessage.get().getString());
+            }
+        }
+    }
+
+    private void queueFetch(ThermooConfig config) {
+        Thread.ofVirtual().start(() -> {
+            try {
+                this.fetch(config);
+            } catch (Exception e) {
+                LOGGER.error("Error fetching Thermoo Patches patch list", e);
+            }
+        });
+    }
+
+    private void fetch(ThermooConfig config) {
+        List<ModContainer> patchAvailableMods;
+
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            PatchList patches = PatchListService.fetchPatchList(client, config.thermooPatchesPatchListUrl());
+            patchAvailableMods = patches.getPatchAvailableMods();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (IOException | VersionParsingException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (!patchAvailableMods.isEmpty()) {
+            LOGGER.warn("Thermoo Patches is recommended for this mod set!");
+            this.nagMessage.set(this.createNagMessage(patchAvailableMods));
+        } else if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Your mod set is patched with Thermoo Patches, great job!");
+        }
+    }
+
+    private Text createNagMessage(List<ModContainer> patchAvailableMods) {
+        MutableText message = Text.translatable("text.thermoo.thermoo-patches-nag.header").formatted(Formatting.BLUE);
+        message.append("\n");
+
+        patchAvailableMods.forEach(mod -> {
+            ModMetadata metadata = mod.getMetadata();
+            Text modEntry = Text.translatable(
+                    "text.thermoo.thermoo-patches-nag.item",
+                    metadata.getName(),
+                    metadata.getId()
+            ).formatted(Formatting.GOLD);
+
+            message.append(modEntry);
+            message.append("\n");
+        });
+
+        message.append(Text.translatable("text.thermoo.thermoo-patches-nag.footer"));
+
+        return message;
+    }
+
+    private ThermooPatchesNag() {
+
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/config/ThermooConfig.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/config/ThermooConfig.java
@@ -22,7 +22,7 @@ public record ThermooConfig(
         );
     }
 
-    public static ThermooConfig initialize() {
+    public static ThermooConfig create() {
         var properties = new Properties(newDefaultConfig());
         File configFile = getConfigFile();
         readConfig(properties, configFile);

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/config/ThermooConfig.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/config/ThermooConfig.java
@@ -3,8 +3,12 @@ package com.github.thedeathlycow.thermoo.impl.config;
 import com.github.thedeathlycow.thermoo.impl.Thermoo;
 import net.fabricmc.loader.api.FabricLoader;
 
-import java.io.*;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 
@@ -24,26 +28,26 @@ public record ThermooConfig(
 
     public static ThermooConfig create() {
         var properties = new Properties(newDefaultConfig());
-        File configFile = getConfigFile();
+        Path configFile = getConfigPath();
         readConfig(properties, configFile);
         return new ThermooConfig(properties);
     }
 
-    private static void readConfig(Properties properties, File file) {
-        try (FileReader reader = new FileReader(file)){
-            properties.load(reader);
+    private static void readConfig(Properties properties, Path path) {
+        try (InputStream input = Files.newInputStream(path)) {
+            properties.load(input);
         } catch (FileNotFoundException e) {
-            writeConfig(newDefaultConfig(), file);
+            writeConfig(newDefaultConfig(), path);
         } catch (IOException e) {
-            Thermoo.LOGGER.error("Unable to read Thermoo config file, falling back to default config", e);
+            Thermoo.LOGGER.error("Unable to read Thermoo config path, falling back to default config", e);
         }
     }
 
-    private static void writeConfig(Properties properties, File file) {
-        try (FileWriter writer = new FileWriter(file)) {
-            properties.store(writer, "Thermoo Config file, used for internal configuration only.");
+    private static void writeConfig(Properties properties, Path path) {
+        try (OutputStream output = Files.newOutputStream(path)) {
+            properties.store(output, "Thermoo Config path, used for internal configuration only.");
         } catch (IOException e) {
-            Thermoo.LOGGER.error("Unable to write Thermoo default config file", e);
+            Thermoo.LOGGER.error("Unable to write Thermoo default config path", e);
         }
     }
 
@@ -56,17 +60,9 @@ public record ThermooConfig(
         return properties;
     }
 
-    private static File getConfigFile() {
-        Path path = FabricLoader.getInstance()
+    private static Path getConfigPath() {
+        return FabricLoader.getInstance()
                 .getConfigDir()
                 .resolve("thermoo.properties");
-
-        File file = path.toFile();
-
-        if (!file.isFile() && file.exists()) {
-            throw new IllegalStateException("Thermoo config is not a file");
-        }
-
-        return file;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/config/ThermooConfig.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/config/ThermooConfig.java
@@ -1,0 +1,72 @@
+package com.github.thedeathlycow.thermoo.impl.config;
+
+import com.github.thedeathlycow.thermoo.impl.Thermoo;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.io.*;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Properties;
+
+public record ThermooConfig(
+        boolean enableThermooPatchesBug,
+        URI thermooPatchesPatchListUrl
+) {
+    private static final String ENABLE_THERMOO_PATCHES_BUG_KEY = "enable_thermoo_patches_bug";
+    private static final String THERMOO_PATCHES_PATCH_LIST_URL_KEY = "thermoo_patches_patch_list_url";
+
+    private ThermooConfig(Properties properties) {
+        this(
+                Boolean.parseBoolean(properties.getProperty(ENABLE_THERMOO_PATCHES_BUG_KEY)),
+                URI.create(properties.getProperty(THERMOO_PATCHES_PATCH_LIST_URL_KEY))
+        );
+    }
+
+    public static ThermooConfig initialize() {
+        var properties = new Properties(newDefaultConfig());
+        File configFile = getConfigFile();
+        readConfig(properties, configFile);
+        return new ThermooConfig(properties);
+    }
+
+    private static void readConfig(Properties properties, File file) {
+        try (FileReader reader = new FileReader(file)){
+            properties.load(reader);
+        } catch (FileNotFoundException e) {
+            writeConfig(properties, file);
+        } catch (IOException e) {
+            Thermoo.LOGGER.error("Unable to read Thermoo config file, falling back to default config", e);
+        }
+    }
+
+    private static void writeConfig(Properties properties, File file) {
+        try (FileWriter writer = new FileWriter(file)) {
+            properties.store(writer, "Thermoo Config file, used for internal configuration only.");
+        } catch (IOException e) {
+            Thermoo.LOGGER.error("Unable to write Thermoo default config file", e);
+        }
+    }
+
+    private static Properties newDefaultConfig() {
+        var properties = new Properties();
+
+        properties.setProperty(ENABLE_THERMOO_PATCHES_BUG_KEY, "true");
+        properties.setProperty(THERMOO_PATCHES_PATCH_LIST_URL_KEY, "https://gist.githubusercontent.com/TheDeathlyCow/1164d3721101f0540d455cc9f63fcac8/raw/74f939ed1a89a0e603891affd3bd9e2d8dc75c8b/thermoo-patches-patch-list.json");
+
+        return properties;
+    }
+
+    private static File getConfigFile() {
+        Path path = FabricLoader.getInstance()
+                .getConfigDir()
+                .resolve("thermoo.properties");
+
+        File file = path.toFile();
+
+        if (!file.isFile()) {
+            throw new IllegalStateException("Thermoo config is not a file");
+        }
+
+        return file;
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/config/ThermooConfig.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/config/ThermooConfig.java
@@ -9,15 +9,15 @@ import java.nio.file.Path;
 import java.util.Properties;
 
 public record ThermooConfig(
-        boolean enableThermooPatchesBug,
+        boolean enableThermooPatchesNag,
         URI thermooPatchesPatchListUrl
 ) {
-    private static final String ENABLE_THERMOO_PATCHES_BUG_KEY = "enable_thermoo_patches_bug";
+    private static final String ENABLE_THERMOO_PATCHES_NAG_KEY = "enable_thermoo_patches_nag";
     private static final String THERMOO_PATCHES_PATCH_LIST_URL_KEY = "thermoo_patches_patch_list_url";
 
     private ThermooConfig(Properties properties) {
         this(
-                Boolean.parseBoolean(properties.getProperty(ENABLE_THERMOO_PATCHES_BUG_KEY)),
+                Boolean.parseBoolean(properties.getProperty(ENABLE_THERMOO_PATCHES_NAG_KEY)),
                 URI.create(properties.getProperty(THERMOO_PATCHES_PATCH_LIST_URL_KEY))
         );
     }
@@ -33,7 +33,7 @@ public record ThermooConfig(
         try (FileReader reader = new FileReader(file)){
             properties.load(reader);
         } catch (FileNotFoundException e) {
-            writeConfig(properties, file);
+            writeConfig(newDefaultConfig(), file);
         } catch (IOException e) {
             Thermoo.LOGGER.error("Unable to read Thermoo config file, falling back to default config", e);
         }
@@ -50,8 +50,8 @@ public record ThermooConfig(
     private static Properties newDefaultConfig() {
         var properties = new Properties();
 
-        properties.setProperty(ENABLE_THERMOO_PATCHES_BUG_KEY, "true");
-        properties.setProperty(THERMOO_PATCHES_PATCH_LIST_URL_KEY, "https://gist.githubusercontent.com/TheDeathlyCow/1164d3721101f0540d455cc9f63fcac8/raw/74f939ed1a89a0e603891affd3bd9e2d8dc75c8b/thermoo-patches-patch-list.json");
+        properties.setProperty(ENABLE_THERMOO_PATCHES_NAG_KEY, "true");
+        properties.setProperty(THERMOO_PATCHES_PATCH_LIST_URL_KEY, "https://gist.githubusercontent.com/TheDeathlyCow/1164d3721101f0540d455cc9f63fcac8/raw/thermoo-patches-patch-list.json");
 
         return properties;
     }
@@ -63,7 +63,7 @@ public record ThermooConfig(
 
         File file = path.toFile();
 
-        if (!file.isFile()) {
+        if (!file.isFile() && file.exists()) {
             throw new IllegalStateException("Thermoo config is not a file");
         }
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/config/ThermooConfig.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/config/ThermooConfig.java
@@ -51,7 +51,7 @@ public record ThermooConfig(
         var properties = new Properties();
 
         properties.setProperty(ENABLE_THERMOO_PATCHES_NAG_KEY, "true");
-        properties.setProperty(THERMOO_PATCHES_PATCH_LIST_URL_KEY, "https://gist.githubusercontent.com/TheDeathlyCow/1164d3721101f0540d455cc9f63fcac8/raw/thermoo-patches-patch-list.json");
+        properties.setProperty(THERMOO_PATCHES_PATCH_LIST_URL_KEY, "https://thermoo.thedeathlycow.com/assets/thermoo-patches-patch-list.json");
 
         return properties;
     }

--- a/src/main/resources/assets/thermoo/lang/en_us.json
+++ b/src/main/resources/assets/thermoo/lang/en_us.json
@@ -37,9 +37,8 @@
     "commands.thermoo.soaking.add.success": "Added %d points to the soaking value of %s (now %d)",
     "commands.thermoo.soaking.remove.success": "Removed %d points from the soaking value of %s (now %d)",
     
-    "text.thermoo.thermoo-patches-nag.header": "Hey there, it looks like you could use Thermoo Patches!",
     "text.thermoo.thermoo-patches-nag.body": "The following mod(s) can work with Thermoo, Frostiful, and/or Scorchful, but you are missing the Thermoo Patches compatibility mod:",
     "text.thermoo.thermoo-patches-nag.item": "- %1$s (%2$s)",
     "text.thermoo.thermoo-patches-nag.footer": "You can get Thermoo Patches at the below link:",
-    "text.thermoo.thermoo-patches-nag.disable": "You may disable this nag message at any time in the thermoo.properties config."
+    "text.thermoo.thermoo-patches-nag.disable": "You may disable this message at any time in the Thermoo config."
 }

--- a/src/main/resources/assets/thermoo/lang/en_us.json
+++ b/src/main/resources/assets/thermoo/lang/en_us.json
@@ -35,5 +35,11 @@
     "commands.thermoo.soaking.get.max.success": "The maximum soaking value of %s is %d",
     "commands.thermoo.soaking.set.success": "Set the soaking value of %s to %d (now %d)",
     "commands.thermoo.soaking.add.success": "Added %d points to the soaking value of %s (now %d)",
-    "commands.thermoo.soaking.remove.success": "Removed %d points from the soaking value of %s (now %d)"
+    "commands.thermoo.soaking.remove.success": "Removed %d points from the soaking value of %s (now %d)",
+    
+    "text.thermoo.thermoo-patches-nag.header": "Hey there, it looks like you could use Thermoo Patches!",
+    "text.thermoo.thermoo-patches-nag.body": "The following mod(s) can work with Thermoo, Frostiful, and/or Scorchful, but you are missing the Thermoo Patches compatibility mod:",
+    "text.thermoo.thermoo-patches-nag.item": "- %1$s (%2$s)",
+    "text.thermoo.thermoo-patches-nag.footer": "You can get Thermoo Patches at the below link:",
+    "text.thermoo.thermoo-patches-nag.disable": "You may disable this nag message at any time in the thermoo.properties config."
 }

--- a/src/test/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListServiceTest.java
+++ b/src/test/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListServiceTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 class PatchListServiceTest {
     private HttpClient mockClient;
-    private URI uri = URI.create("https://www.thedeathlycow.com/thermoo-patches-patch-list.json"); // doesnt need to point at anything in particular
+    private final URI uri = URI.create("https://www.thedeathlycow.com/thermoo-patches-patch-list.json"); // doesnt need to point at anything in particular
 
     @BeforeEach
     void setup() {
@@ -23,7 +23,7 @@ class PatchListServiceTest {
     }
 
     @Test
-    void when2xx_thenParsePatchList() throws IOException, InterruptedException {
+    void when200_thenParsePatchList() throws IOException, InterruptedException {
         String responseBody = """
                 {
                     "patches": [
@@ -50,7 +50,7 @@ class PatchListServiceTest {
         Mockito.when(mockResponse.body()).thenReturn(responseBody);
         Mockito.when(mockClient.send(Mockito.any(), Mockito.any())).thenReturn(mockResponse);
 
-        PatchList patchList = PatchListService.fetchPatches(mockClient, uri);
+        PatchList patchList = PatchListService.fetchPatchList(mockClient, uri);
 
         PatchList expectedPatchList = new PatchList(
                 List.of(
@@ -62,22 +62,12 @@ class PatchListServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {400, 401, 403, 404})
-    void when4xx_thenThrowsIOException(int statusCode) throws IOException, InterruptedException {
+    @ValueSource(ints = {400, 401, 403, 404, 500, 502})
+    void whenError_thenThrowsIOException(int statusCode) throws IOException, InterruptedException {
         HttpResponse<Object> mockResponse = (HttpResponse<Object>) Mockito.mock(HttpResponse.class);
         Mockito.when(mockResponse.statusCode()).thenReturn(statusCode);
         Mockito.when(mockClient.send(Mockito.any(), Mockito.any())).thenReturn(mockResponse);
 
-        Assertions.assertThrows(IOException.class, () -> PatchListService.fetchPatches(mockClient, uri));
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {500, 502})
-    void when5xx_thenThrowsIOException(int statusCode) throws IOException, InterruptedException {
-        HttpResponse<Object> mockResponse = (HttpResponse<Object>) Mockito.mock(HttpResponse.class);
-        Mockito.when(mockResponse.statusCode()).thenReturn(statusCode);
-        Mockito.when(mockClient.send(Mockito.any(), Mockito.any())).thenReturn(mockResponse);
-
-        Assertions.assertThrows(IOException.class, () -> PatchListService.fetchPatches(mockClient, uri));
+        Assertions.assertThrows(IOException.class, () -> PatchListService.fetchPatchList(mockClient, uri));
     }
 }

--- a/src/test/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListServiceTest.java
+++ b/src/test/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListServiceTest.java
@@ -1,0 +1,81 @@
+package com.github.thedeathlycow.thermoo.impl.compat;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+class PatchListServiceTest {
+    private HttpClient mockClient;
+
+    @BeforeEach
+    void setup() {
+        mockClient = Mockito.mock(HttpClient.class);
+    }
+
+    @Test
+    void when2xx_thenParsePatchList() throws IOException, InterruptedException {
+        String responseBody = """
+                {
+                    "patches": [
+                        {
+                            "minecraft_version": "1.21.1",
+                            "mods": [
+                                "seasonsmod",
+                                "hudmod",
+                                "othermod"
+                            ]
+                        },
+                        {
+                            "minecraft_version": "1.12.2",
+                            "mods": [
+                                "seasonsmod",
+                                "hudmod"
+                            ]
+                        }
+                    ]
+                }
+                """;
+        HttpResponse<Object> mockResponse = (HttpResponse<Object>) Mockito.mock(HttpResponse.class);
+        Mockito.when(mockResponse.statusCode()).thenReturn(200);
+        Mockito.when(mockResponse.body()).thenReturn(responseBody);
+        Mockito.when(mockClient.send(Mockito.any(), Mockito.any())).thenReturn(mockResponse);
+
+        PatchList patchList = PatchListService.fetchPatches(mockClient);
+
+        PatchList expectedPatchList = new PatchList(
+                List.of(
+                        new PatchedVersion("1.21.1", List.of("seasonsmod", "hudmod", "othermod")),
+                        new PatchedVersion("1.12.2", List.of("seasonsmod", "hudmod"))
+                )
+        );
+        Assertions.assertEquals(expectedPatchList, patchList);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {400, 401, 403, 404})
+    void when4xx_thenThrowsIOException(int statusCode) throws IOException, InterruptedException {
+        HttpResponse<Object> mockResponse = (HttpResponse<Object>) Mockito.mock(HttpResponse.class);
+        Mockito.when(mockResponse.statusCode()).thenReturn(statusCode);
+        Mockito.when(mockClient.send(Mockito.any(), Mockito.any())).thenReturn(mockResponse);
+
+        Assertions.assertThrows(IOException.class, () -> PatchListService.fetchPatches(mockClient));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {500, 502})
+    void when5xx_thenThrowsIOException(int statusCode) throws IOException, InterruptedException {
+        HttpResponse<Object> mockResponse = (HttpResponse<Object>) Mockito.mock(HttpResponse.class);
+        Mockito.when(mockResponse.statusCode()).thenReturn(statusCode);
+        Mockito.when(mockClient.send(Mockito.any(), Mockito.any())).thenReturn(mockResponse);
+
+        Assertions.assertThrows(IOException.class, () -> PatchListService.fetchPatches(mockClient));
+    }
+}

--- a/src/test/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListServiceTest.java
+++ b/src/test/java/com/github/thedeathlycow/thermoo/impl/compat/PatchListServiceTest.java
@@ -8,12 +8,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.util.List;
 
 class PatchListServiceTest {
     private HttpClient mockClient;
+    private URI uri = URI.create("https://www.thedeathlycow.com/thermoo-patches-patch-list.json"); // doesnt need to point at anything in particular
 
     @BeforeEach
     void setup() {
@@ -48,7 +50,7 @@ class PatchListServiceTest {
         Mockito.when(mockResponse.body()).thenReturn(responseBody);
         Mockito.when(mockClient.send(Mockito.any(), Mockito.any())).thenReturn(mockResponse);
 
-        PatchList patchList = PatchListService.fetchPatches(mockClient);
+        PatchList patchList = PatchListService.fetchPatches(mockClient, uri);
 
         PatchList expectedPatchList = new PatchList(
                 List.of(
@@ -66,7 +68,7 @@ class PatchListServiceTest {
         Mockito.when(mockResponse.statusCode()).thenReturn(statusCode);
         Mockito.when(mockClient.send(Mockito.any(), Mockito.any())).thenReturn(mockResponse);
 
-        Assertions.assertThrows(IOException.class, () -> PatchListService.fetchPatches(mockClient));
+        Assertions.assertThrows(IOException.class, () -> PatchListService.fetchPatches(mockClient, uri));
     }
 
     @ParameterizedTest
@@ -76,6 +78,6 @@ class PatchListServiceTest {
         Mockito.when(mockResponse.statusCode()).thenReturn(statusCode);
         Mockito.when(mockClient.send(Mockito.any(), Mockito.any())).thenReturn(mockResponse);
 
-        Assertions.assertThrows(IOException.class, () -> PatchListService.fetchPatches(mockClient));
+        Assertions.assertThrows(IOException.class, () -> PatchListService.fetchPatches(mockClient, uri));
     }
 }


### PR DESCRIPTION
Adds a message in chat that nags the player to install Thermoo Patches if they do not have Thermoo Patches install, and have another mod loaded that is patched by that mod. 

This nag can be disabled in a new config: `thermoo.properties` 

This does not prompt the player to update Thermoo Patches if they have an old version installed, that is better handled by modmenu/launchers.