### PR TITLE
Extensions for MojMap

### DIFF
--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/EnvironmentDefinition.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/EnvironmentDefinition.java
@@ -25,7 +25,7 @@ public final class EnvironmentDefinition {
                     RegistryCodecs.homogeneousList(Registries.BIOME)
                             .optionalFieldOf("exclude_biomes", HolderSet.empty())
                             .forGetter(EnvironmentDefinition::excludeBiomes),
-                    EnvironmentProvider.ENTRY_CODEC
+                    EnvironmentProvider.HOLDER_CODEC
                             .fieldOf("provider")
                             .forGetter(EnvironmentDefinition::provider),
                     Codec.INT

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/BiomePrecipitationTypeEnvironmentProvider.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/BiomePrecipitationTypeEnvironmentProvider.java
@@ -76,7 +76,7 @@ public final class BiomePrecipitationTypeEnvironmentProvider implements Environm
     private static MapCodec<Map<Biome.Precipitation, Holder<EnvironmentProvider>>> createPrecipitationMapCodec() {
         return Codec.simpleMap(
                 Biome.Precipitation.CODEC,
-                EnvironmentProvider.ENTRY_CODEC,
+                EnvironmentProvider.HOLDER_CODEC,
                 StringRepresentable.keys(Biome.Precipitation.values())
         ).validate(map -> {
             if (map.isEmpty()) {

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/EnvironmentProvider.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/EnvironmentProvider.java
@@ -18,10 +18,17 @@ public interface EnvironmentProvider {
     Codec<EnvironmentProvider> ELEMENT_CODEC = ThermooRegistries.ENVIRONMENT_PROVIDER_TYPE.byNameCodec()
             .dispatch("type", EnvironmentProvider::getType, EnvironmentProviderType::codec);
 
-    Codec<Holder<EnvironmentProvider>> ENTRY_CODEC = RegistryFileCodec.create(
+    Codec<Holder<EnvironmentProvider>> HOLDER_CODEC = RegistryFileCodec.create(
             ThermooRegistryKeys.ENVIRONMENT_PROVIDER,
             ELEMENT_CODEC
     );
+
+    /**
+     * @deprecated This field was named based on Yarn mappings. Use {@link #HOLDER_CODEC} to better confirm to Official
+     * Mappings.
+     */
+    @Deprecated(since = "8.1.0")
+    Codec<Holder<EnvironmentProvider>> ENTRY_CODEC = HOLDER_CODEC;
 
     /**
      * Builds the current environment parameter components at a point and biome in a world into a reducible builder.

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/EnvironmentProvider.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/EnvironmentProvider.java
@@ -27,7 +27,7 @@ public interface EnvironmentProvider {
      * @deprecated This field was named based on Yarn mappings. Use {@link #HOLDER_CODEC} to better confirm to Official
      * Mappings.
      */
-    @Deprecated(since = "8.1.0")
+    @Deprecated(since = "8.1.0", forRemoval = true)
     Codec<Holder<EnvironmentProvider>> ENTRY_CODEC = HOLDER_CODEC;
 
     /**

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/LightThresholdLightProvider.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/LightThresholdLightProvider.java
@@ -35,10 +35,10 @@ public class LightThresholdLightProvider implements EnvironmentProvider {
                     Codec.intRange(0, 15)
                             .fieldOf("threshold")
                             .forGetter(LightThresholdLightProvider::threshold),
-                    EnvironmentProvider.ENTRY_CODEC
+                    EnvironmentProvider.HOLDER_CODEC
                             .fieldOf("above")
                             .forGetter(LightThresholdLightProvider::above),
-                    EnvironmentProvider.ENTRY_CODEC
+                    EnvironmentProvider.HOLDER_CODEC
                             .fieldOf("below")
                             .forGetter(LightThresholdLightProvider::below)
             ).apply(instance, LightThresholdLightProvider::new)

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/LightThresholdLightProvider.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/LightThresholdLightProvider.java
@@ -127,7 +127,7 @@ public class LightThresholdLightProvider implements EnvironmentProvider {
      * @return Returns the light layer of this provider.
      * @deprecated This method is named based on Yarn, use {@link #lightLayer()} to better conform to official mappings.
      */
-    @Deprecated(since = "8.1.0")
+    @Deprecated(since = "8.1.0", forRemoval = true)
     public Optional<LightLayer> lightType() {
         return this.lightLayer;
     }

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/LightThresholdLightProvider.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/LightThresholdLightProvider.java
@@ -28,7 +28,7 @@ public class LightThresholdLightProvider implements EnvironmentProvider {
                                     name -> LightLayer.valueOf(name.toUpperCase())
                             )
                             .optionalFieldOf("light_type")
-                            .forGetter(LightThresholdLightProvider::lightType),
+                            .forGetter(LightThresholdLightProvider::lightLayer),
                     Codec.BOOL
                             .optionalFieldOf("apply_ambient_darkness", true)
                             .forGetter(LightThresholdLightProvider::applyAmbientDarkness),
@@ -44,7 +44,7 @@ public class LightThresholdLightProvider implements EnvironmentProvider {
             ).apply(instance, LightThresholdLightProvider::new)
     );
 
-    private final Optional<LightLayer> lightType;
+    private final Optional<LightLayer> lightLayer;
     private final boolean applyAmbientDarkness;
     private final int threshold;
     private final Holder<EnvironmentProvider> above;
@@ -74,13 +74,13 @@ public class LightThresholdLightProvider implements EnvironmentProvider {
     }
 
     private LightThresholdLightProvider(
-            Optional<LightLayer> lightType,
+            Optional<LightLayer> lightLayer,
             boolean applyAmbientDarkness,
             int threshold,
             Holder<EnvironmentProvider> above,
             Holder<EnvironmentProvider> below
     ) {
-        this.lightType = lightType;
+        this.lightLayer = lightLayer;
         this.applyAmbientDarkness = applyAmbientDarkness;
         this.threshold = threshold;
         this.above = above;
@@ -100,11 +100,11 @@ public class LightThresholdLightProvider implements EnvironmentProvider {
      */
     @Override
     public void buildCurrentComponents(Level level, BlockPos pos, Holder<Biome> biome, DataComponentMap.Builder builder) {
-        int lightLevel = this.lightType
+        int lightLevel = this.lightLayer
                 .map(type -> level.getBrightness(type, pos))
                 .orElseGet(() -> level.getMaxLocalRawBrightness(pos));
 
-        if (this.applyAmbientDarkness && this.lightType.orElse(null) == LightLayer.SKY) {
+        if (this.applyAmbientDarkness && this.lightLayer.orElse(null) == LightLayer.SKY) {
             lightLevel -= level.getSkyDarken();
         }
 
@@ -125,9 +125,21 @@ public class LightThresholdLightProvider implements EnvironmentProvider {
      * to determine light level.
      *
      * @return Returns the light layer of this provider.
+     * @deprecated This method is named based on Yarn, use {@link #lightLayer()} to better conform to official mappings.
      */
+    @Deprecated(since = "8.1.0")
     public Optional<LightLayer> lightType() {
-        return this.lightType;
+        return this.lightLayer;
+    }
+
+    /**
+     * The optional light layer of this provider. If not specified, uses {@link net.minecraft.world.level.LevelReader#getMaxLocalRawBrightness(BlockPos)}
+     * to determine light level.
+     *
+     * @return Returns the light layer of this provider.
+     */
+    public Optional<LightLayer> lightLayer() {
+        return this.lightLayer;
     }
 
     /**

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/ModifyEnvironmentProvider.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/ModifyEnvironmentProvider.java
@@ -24,7 +24,7 @@ public final class ModifyEnvironmentProvider implements EnvironmentProvider {
                     RegistryCodecs.homogeneousList(ThermooRegistryKeys.ENVIRONMENT_PROVIDER)
                             .fieldOf("modifiers")
                             .forGetter(ModifyEnvironmentProvider::modifiers),
-                    EnvironmentProvider.ENTRY_CODEC
+                    EnvironmentProvider.HOLDER_CODEC
                             .fieldOf("base")
                             .forGetter(ModifyEnvironmentProvider::base)
             ).apply(instance, ModifyEnvironmentProvider::new)

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/SeasonalEnvironmentProvider.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/SeasonalEnvironmentProvider.java
@@ -90,7 +90,7 @@ public abstract sealed class SeasonalEnvironmentProvider implements EnvironmentP
     protected static MapCodec<Map<ThermooSeason, Holder<EnvironmentProvider>>> createSeasonMapCodec() {
         return Codec.simpleMap(
                 ThermooSeason.CODEC,
-                EnvironmentProvider.ENTRY_CODEC,
+                EnvironmentProvider.HOLDER_CODEC,
                 StringRepresentable.keys(ThermooSeason.values())
         ).validate(seasonMap -> {
             if (seasonMap.isEmpty()) {

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/WeatherStateEnvironmentProvider.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/provider/WeatherStateEnvironmentProvider.java
@@ -21,13 +21,13 @@ import java.util.Optional;
 public final class WeatherStateEnvironmentProvider implements EnvironmentProvider {
     public static final MapCodec<WeatherStateEnvironmentProvider> CODEC = RecordCodecBuilder.mapCodec(
             instance -> instance.group(
-                    EnvironmentProvider.ENTRY_CODEC
+                    EnvironmentProvider.HOLDER_CODEC
                             .optionalFieldOf("clear")
                             .forGetter(WeatherStateEnvironmentProvider::clear),
-                    EnvironmentProvider.ENTRY_CODEC
+                    EnvironmentProvider.HOLDER_CODEC
                             .optionalFieldOf("rain")
                             .forGetter(WeatherStateEnvironmentProvider::rain),
-                    EnvironmentProvider.ENTRY_CODEC
+                    EnvironmentProvider.HOLDER_CODEC
                             .optionalFieldOf("thunder")
                             .forGetter(WeatherStateEnvironmentProvider::thunder)
             ).apply(instance, WeatherStateEnvironmentProvider::new)

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/season/ThermooSeasonEvents.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/season/ThermooSeasonEvents.java
@@ -18,8 +18,7 @@ public final class ThermooSeasonEvents {
     }
 
     /**
-     * Retrieves the current season. This event just places season integration into
-     * a common source.
+     * Retrieves the current season. This event just places season integration into a common source.
      * <p>
      * If any listener returns a non-empty season, then all further processing is cancelled and that season is returned.
      * <p>
@@ -42,7 +41,7 @@ public final class ThermooSeasonEvents {
     );
 
     /**
-     * Retrieves the current tropical season at a positive in the world. If the position queried is not in a tropical
+     * Retrieves the current tropical season at a positive in the level. If the position queried is not in a tropical
      * biome, or a seasons mod is not loaded, then empty should be returned.
      * <p>
      * If any listener returns a non-empty season, then all further processing is cancelled and that season is returned.

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/AttributeModifierTemperatureEffect.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/AttributeModifierTemperatureEffect.java
@@ -30,7 +30,7 @@ public final class AttributeModifierTemperatureEffect extends TemperatureEffect<
                             .forGetter(Config::attribute),
                     ResourceLocation.CODEC
                             .fieldOf("id")
-                            .forGetter(Config::id),
+                            .forGetter(Config::location),
                     AttributeModifier.Operation.CODEC
                             .fieldOf("operation")
                             .forGetter(Config::operation)
@@ -44,10 +44,10 @@ public final class AttributeModifierTemperatureEffect extends TemperatureEffect<
     @Override
     public void apply(LivingEntity victim, ServerLevel serverWorld, Config config) {
         AttributeInstance attrInstance = victim.getAttribute(config.attribute);
-        if (attrInstance != null && !attrInstance.hasModifier(config.id)) {
+        if (attrInstance != null && !attrInstance.hasModifier(config.location)) {
             attrInstance.addTransientModifier(
                     new AttributeModifier(
-                            config.id,
+                            config.location,
                             config.value,
                             config.operation
                     )
@@ -67,7 +67,7 @@ public final class AttributeModifierTemperatureEffect extends TemperatureEffect<
         super.remove(victim, serverWorld, config);
         AttributeInstance attributeInstance = victim.getAttribute(config.attribute);
         if (attributeInstance != null) {
-            attributeInstance.removeModifier(config.id);
+            attributeInstance.removeModifier(config.location);
         }
     }
 
@@ -75,9 +75,17 @@ public final class AttributeModifierTemperatureEffect extends TemperatureEffect<
     public record Config(
             float value,
             Holder<Attribute> attribute,
-            ResourceLocation id,
+            ResourceLocation location,
             AttributeModifier.Operation operation
     ) {
+        /**
+         * @return Returns the value of {@link #location}
+         * @deprecated This field was named based on Yarn mappings. Use {@link #location} to better conform to Official
+         * Mappings.
+         */
+        @Deprecated(since = "8.1.0", forRemoval = true)
+        public ResourceLocation id() {
+            return location;
+        }
     }
-
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/ScalingAttributeModifierTemperatureEffect.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/ScalingAttributeModifierTemperatureEffect.java
@@ -30,7 +30,7 @@ public final class ScalingAttributeModifierTemperatureEffect extends Temperature
                             .forGetter(Config::attribute),
                     ResourceLocation.CODEC
                             .fieldOf("id")
-                            .forGetter(Config::id),
+                            .forGetter(Config::location),
                     AttributeModifier.Operation.CODEC
                             .fieldOf("operation")
                             .forGetter(Config::operation)
@@ -53,7 +53,7 @@ public final class ScalingAttributeModifierTemperatureEffect extends Temperature
 
         attrInstance.addTransientModifier(
                 new AttributeModifier(
-                        config.id,
+                        config.location,
                         amount,
                         config.operation
                 )
@@ -69,7 +69,7 @@ public final class ScalingAttributeModifierTemperatureEffect extends Temperature
             return false;
         }
 
-        AttributeModifier modifier = attrInstance.getModifier(config.id);
+        AttributeModifier modifier = attrInstance.getModifier(config.location);
         if (modifier == null) {
             return true;
         }
@@ -81,7 +81,7 @@ public final class ScalingAttributeModifierTemperatureEffect extends Temperature
 
         if (shouldApply) {
             // remove the modifier - even if the other predicate tests fail
-            attrInstance.removeModifier(config.id);
+            attrInstance.removeModifier(config.location);
         }
 
         return shouldApply;
@@ -90,9 +90,17 @@ public final class ScalingAttributeModifierTemperatureEffect extends Temperature
     public record Config(
             float scale,
             Holder<Attribute> attribute,
-            ResourceLocation id,
+            ResourceLocation location,
             AttributeModifier.Operation operation
     ) {
+        /**
+         * @return Returns the value of {@link #location}
+         * @deprecated This field was named based on Yarn mappings. Use {@link #location} to better conform to Official
+         * Mappings.
+         */
+        @Deprecated(since = "8.1.0", forRemoval = true)
+        public ResourceLocation id() {
+            return location;
+        }
     }
-
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/StatusEffectTemperatureEffect.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/StatusEffectTemperatureEffect.java
@@ -20,7 +20,6 @@ import java.util.List;
  * effects to all be applied at once.
  */
 public final class StatusEffectTemperatureEffect extends TemperatureEffect<StatusEffectTemperatureEffect.Config> {
-
     public static final Codec<Config> CODEC = RecordCodecBuilder.create(
             instance -> instance.group(
                     Codec.list(Config.ConfigEffect.CODEC)
@@ -28,7 +27,6 @@ public final class StatusEffectTemperatureEffect extends TemperatureEffect<Statu
                             .forGetter(Config::effects)
             ).apply(instance, Config::new)
     );
-
 
     public StatusEffectTemperatureEffect(Codec<Config> configCodec) {
         super(configCodec);
@@ -93,6 +91,4 @@ public final class StatusEffectTemperatureEffect extends TemperatureEffect<Statu
             );
         }
     }
-
-
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffects.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/effects/TemperatureEffects.java
@@ -39,9 +39,17 @@ public final class TemperatureEffects {
      * Applies {@linkplain net.minecraft.world.effect.MobEffect mob effects} to entities based on their
      * temperature
      */
-    public static final TemperatureEffect<StatusEffectTemperatureEffect.Config> STATUS_EFFECT = new StatusEffectTemperatureEffect(
+    public static final TemperatureEffect<StatusEffectTemperatureEffect.Config> MOB_EFFECT = new StatusEffectTemperatureEffect(
             StatusEffectTemperatureEffect.CODEC
     );
+
+    /**
+     * @deprecated This field was named based on Yarn Mappings, use {@link #MOB_EFFECT} to better conform to Official
+     * Mappings. Also note that when this field is removed, the underlying class will also be renamed to
+     * MobEffectTemperatureEffect.
+     */
+    @Deprecated(since = "8.1.0", forRemoval = true)
+    public static final TemperatureEffect<StatusEffectTemperatureEffect.Config> STATUS_EFFECT = MOB_EFFECT;
 
     /**
      * Applies scaled {@linkplain net.minecraft.world.entity.ai.attributes.AttributeModifier attribute modifiers} to

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/event/EnvironmentTickContext.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/temperature/event/EnvironmentTickContext.java
@@ -24,10 +24,20 @@ public interface EnvironmentTickContext<T extends TemperatureAware & Soakable> {
     T affected();
 
     /**
-     * The server world of the affected temperature aware/soakable
+     * @deprecated This method was named based on Yarn Mappings. Use {@link #level()} to better conform to Official
+     * Mappings.
      */
     @NotNull
-    ServerLevel world();
+    @Deprecated(since = "8.1.0", forRemoval = true)
+    default ServerLevel world() {
+        return this.level();
+    }
+
+    /**
+     * The server level of the affected temperature aware/soakable
+     */
+    @NotNull
+    ServerLevel level();
 
     /**
      * The block position of the affected temperature aware/soakable. This should be preferred over using methods such as

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooCommonRegisters.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooCommonRegisters.java
@@ -20,6 +20,11 @@ public class ThermooCommonRegisters {
         registerTemperatureEffect("scaling_attribute_modifier", TemperatureEffects.SCALING_ATTRIBUTE_MODIFIER);
         registerTemperatureEffect("attribute_modifier", TemperatureEffects.ATTRIBUTE_MODIFIER);
         registerTemperatureEffect("damage", TemperatureEffects.DAMAGE);
+
+        ThermooRegistries.TEMPERATURE_EFFECTS.addAlias(
+                Thermoo.location("mob_effect"),
+                Thermoo.location("status_effect")
+        );
     }
 
     public static void registerEnvironmentProviderTypes() {

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooCommonRegisters.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooCommonRegisters.java
@@ -16,14 +16,14 @@ public class ThermooCommonRegisters {
         registerTemperatureEffect("empty", TemperatureEffects.EMPTY);
         registerTemperatureEffect("sequence", TemperatureEffects.SEQUENCE);
         registerTemperatureEffect("function", TemperatureEffects.FUNCTION);
-        registerTemperatureEffect("status_effect", TemperatureEffects.STATUS_EFFECT);
+        registerTemperatureEffect("mob_effect", TemperatureEffects.MOB_EFFECT);
         registerTemperatureEffect("scaling_attribute_modifier", TemperatureEffects.SCALING_ATTRIBUTE_MODIFIER);
         registerTemperatureEffect("attribute_modifier", TemperatureEffects.ATTRIBUTE_MODIFIER);
         registerTemperatureEffect("damage", TemperatureEffects.DAMAGE);
 
         ThermooRegistries.TEMPERATURE_EFFECTS.addAlias(
-                Thermoo.location("mob_effect"),
-                Thermoo.location("status_effect")
+                Thermoo.location("status_effect"),
+                Thermoo.location("mob_effect")
         );
     }
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/EnvironmentTickContextImpl.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/EnvironmentTickContextImpl.java
@@ -9,7 +9,7 @@ import net.minecraft.server.level.ServerLevel;
 
 public record EnvironmentTickContextImpl<T extends TemperatureAware & Soakable>(
         T affected,
-        ServerLevel world,
+        ServerLevel level,
         BlockPos pos,
         DataComponentMap components
 ) implements EnvironmentTickContext<T> {


### PR DESCRIPTION
While no breaking changes are planned to be made at this time, a few fields and methods have been renamed to better conform to Official Mappings standards. These are as follows:

- `EnvironmentProvider.ENTRY_CODEC` -> `EnvironmentProvider.HOLDER_CODEC`
- `LightThresholdLightProvider#lightType` -> `LightThresholdLightProvider#lightLayer`
- `AttributeModifierTemperatureEffect$Config#id` -> `AttributeModifierTemperatureEffect$Config#location`
- `ScalingAttributeModifierTemperatureEffect$Config#id` -> `ScalingAttributeModifierTemperatureEffect$Config#location`
- `EnvironmentTickContext#world` -> `EnvironmentTickContext#level`
- `TemperatureEffects.STATUS_EFFECT` -> `TemperatureEffects.MOB_EFFECT`

The resource location of the temperature effect type `thermoo:status_effect` was changed to `thermoo:mob_effect`, however an alias has been added to allow existing datapacks to continue to work.

All old fields and methods have been deprecated and just redirect to the new ones, so there are no breaking changes.

When Minecraft fully moves over to using the unobfuscated jar (the update after Mounts of Mayhem), the old fields will be removed and other names, particularly class names, that could not be easily changed without breaking the public API will also be changed.