### PR TITLE
Environment Attribute Integration

### DIFF
--- a/src/gametest/resources/data/thermoo-test/thermoo/environment/seasonal_plains.json
+++ b/src/gametest/resources/data/thermoo-test/thermoo/environment/seasonal_plains.json
@@ -1,6 +1,7 @@
 {
     "biomes": [
-        "minecraft:plains"
+        "minecraft:plains",
+        "thermoo-test:summer_plains"
     ],
     "provider": {
         "type": "thermoo:seasonal/temperate",

--- a/src/gametest/resources/data/thermoo-test/worldgen/biome/summer_plains.json
+++ b/src/gametest/resources/data/thermoo-test/worldgen/biome/summer_plains.json
@@ -1,0 +1,203 @@
+{
+    "attributes": {
+        "thermoo:gameplay/temperate_season": {
+            "value": "summer"
+        }
+    },
+    "carvers": [
+        "minecraft:cave",
+        "minecraft:cave_extra_underground",
+        "minecraft:canyon"
+    ],
+    "downfall": 0.4,
+    "effects": {
+        "water_color": "#3f76e4"
+    },
+    "features": [
+        [],
+        [
+            "minecraft:lake_lava_underground",
+            "minecraft:lake_lava_surface"
+        ],
+        [
+            "minecraft:amethyst_geode"
+        ],
+        [
+            "minecraft:monster_room",
+            "minecraft:monster_room_deep"
+        ],
+        [],
+        [],
+        [
+            "minecraft:ore_dirt",
+            "minecraft:ore_gravel",
+            "minecraft:ore_granite_upper",
+            "minecraft:ore_granite_lower",
+            "minecraft:ore_diorite_upper",
+            "minecraft:ore_diorite_lower",
+            "minecraft:ore_andesite_upper",
+            "minecraft:ore_andesite_lower",
+            "minecraft:ore_tuff",
+            "minecraft:ore_coal_upper",
+            "minecraft:ore_coal_lower",
+            "minecraft:ore_iron_upper",
+            "minecraft:ore_iron_middle",
+            "minecraft:ore_iron_small",
+            "minecraft:ore_gold",
+            "minecraft:ore_gold_lower",
+            "minecraft:ore_redstone",
+            "minecraft:ore_redstone_lower",
+            "minecraft:ore_diamond",
+            "minecraft:ore_diamond_medium",
+            "minecraft:ore_diamond_large",
+            "minecraft:ore_diamond_buried",
+            "minecraft:ore_lapis",
+            "minecraft:ore_lapis_buried",
+            "minecraft:ore_copper",
+            "minecraft:underwater_magma",
+            "minecraft:disk_sand",
+            "minecraft:disk_clay",
+            "minecraft:disk_gravel"
+        ],
+        [],
+        [
+            "minecraft:spring_water",
+            "minecraft:spring_lava"
+        ],
+        [
+            "minecraft:glow_lichen",
+            "minecraft:patch_tall_grass_2",
+            "minecraft:patch_bush",
+            "minecraft:trees_plains",
+            "minecraft:flower_plains",
+            "minecraft:patch_grass_plain",
+            "minecraft:brown_mushroom_normal",
+            "minecraft:red_mushroom_normal",
+            "minecraft:patch_pumpkin",
+            "minecraft:patch_sugar_cane",
+            "minecraft:patch_firefly_bush_near_water"
+        ],
+        [
+            "minecraft:freeze_top_layer"
+        ]
+    ],
+    "has_precipitation": true,
+    "spawn_costs": {},
+    "spawners": {
+        "ambient": [
+            {
+                "type": "minecraft:bat",
+                "maxCount": 8,
+                "minCount": 8,
+                "weight": 10
+            }
+        ],
+        "axolotls": [],
+        "creature": [
+            {
+                "type": "minecraft:sheep",
+                "maxCount": 4,
+                "minCount": 4,
+                "weight": 12
+            },
+            {
+                "type": "minecraft:pig",
+                "maxCount": 4,
+                "minCount": 4,
+                "weight": 10
+            },
+            {
+                "type": "minecraft:chicken",
+                "maxCount": 4,
+                "minCount": 4,
+                "weight": 10
+            },
+            {
+                "type": "minecraft:cow",
+                "maxCount": 4,
+                "minCount": 4,
+                "weight": 8
+            },
+            {
+                "type": "minecraft:horse",
+                "maxCount": 6,
+                "minCount": 2,
+                "weight": 5
+            },
+            {
+                "type": "minecraft:donkey",
+                "maxCount": 3,
+                "minCount": 1,
+                "weight": 1
+            }
+        ],
+        "misc": [],
+        "monster": [
+            {
+                "type": "minecraft:spider",
+                "maxCount": 4,
+                "minCount": 4,
+                "weight": 100
+            },
+            {
+                "type": "minecraft:zombie",
+                "maxCount": 4,
+                "minCount": 4,
+                "weight": 90
+            },
+            {
+                "type": "minecraft:zombie_villager",
+                "maxCount": 1,
+                "minCount": 1,
+                "weight": 5
+            },
+            {
+                "type": "minecraft:zombie_horse",
+                "maxCount": 1,
+                "minCount": 1,
+                "weight": 5
+            },
+            {
+                "type": "minecraft:skeleton",
+                "maxCount": 4,
+                "minCount": 4,
+                "weight": 100
+            },
+            {
+                "type": "minecraft:creeper",
+                "maxCount": 4,
+                "minCount": 4,
+                "weight": 100
+            },
+            {
+                "type": "minecraft:slime",
+                "maxCount": 4,
+                "minCount": 4,
+                "weight": 100
+            },
+            {
+                "type": "minecraft:enderman",
+                "maxCount": 4,
+                "minCount": 1,
+                "weight": 10
+            },
+            {
+                "type": "minecraft:witch",
+                "maxCount": 1,
+                "minCount": 1,
+                "weight": 5
+            }
+        ],
+        "underground_water_creature": [
+            {
+                "type": "minecraft:glow_squid",
+                "maxCount": 6,
+                "minCount": 4,
+                "weight": 10
+            }
+        ],
+        "water_ambient": [],
+        "water_creature": []
+    },
+    "temperature": 0.8
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooAttributeTypes.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooAttributeTypes.java
@@ -1,0 +1,30 @@
+package com.github.thedeathlycow.thermoo.api.environment.attribute;
+
+import com.github.thedeathlycow.thermoo.api.season.TemperateSeason;
+import com.github.thedeathlycow.thermoo.api.season.TropicalSeason;
+import com.github.thedeathlycow.thermoo.impl.Thermoo;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.attribute.AttributeType;
+
+import java.util.Optional;
+
+public final class ThermooAttributeTypes {
+    public static final AttributeType<Optional<TemperateSeason>> TEMPERATE_SEASON = register(
+            "temperate_season",
+            AttributeType.ofNotInterpolated(TemperateSeason.CODEC.optionalFieldOf("value").codec())
+    );
+
+    public static final AttributeType<Optional<TropicalSeason>> TROPICAL_SEASON = register(
+            "tropical_season",
+            AttributeType.ofNotInterpolated(TropicalSeason.CODEC.optionalFieldOf("value").codec())
+    );
+
+    private static <V> AttributeType<V> register(String name, AttributeType<V> type) {
+        return Registry.register(BuiltInRegistries.ATTRIBUTE_TYPE, Thermoo.id(name), type);
+    }
+
+    private ThermooAttributeTypes() {
+
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooAttributeTypes.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooAttributeTypes.java
@@ -8,15 +8,35 @@ import net.minecraft.world.attribute.AttributeType;
 
 import java.util.Optional;
 
+/**
+ * Thermoo analogue of {@link net.minecraft.world.attribute.AttributeTypes}.
+ * <p>
+ * Provides the attribute type definitions for Thermoo's custom environment attributes.
+ */
 public final class ThermooAttributeTypes {
+    /**
+     * An attribute type that holds an optional temperate season. This attribute type is not interpolated.
+     * <p>
+     * This attribute type has no defined modifier operation.
+     */
     public static final AttributeType<Optional<TemperateSeason>> TEMPERATE_SEASON = AttributeType.ofNotInterpolated(
             TemperateSeason.CODEC.optionalFieldOf("value").codec()
     );
 
+    /**
+     * An attribute type that holds an optional tropical season. This attribute type is not interpolated.
+     * <p>
+     * This attribute type has no defined modifier operation.
+     */
     public static final AttributeType<Optional<TropicalSeason>> TROPICAL_SEASON = AttributeType.ofNotInterpolated(
             TropicalSeason.CODEC.optionalFieldOf("value").codec()
     );
 
+    /**
+     * An attribute type that holds a temperature record. This attribute type is interpolated.
+     * <p>
+     * It may be modified with the operations add, subtract, minimum, and maximum.
+     */
     public static final AttributeType<TemperatureRecord> TEMPERATURE = AttributeType.ofInterpolated(
             TemperatureRecord.CODEC,
             TemperatureModifier.TEMPERATURE_RECORD_LIBRARY,

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooAttributeTypes.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooAttributeTypes.java
@@ -2,6 +2,8 @@ package com.github.thedeathlycow.thermoo.api.environment.attribute;
 
 import com.github.thedeathlycow.thermoo.api.season.TemperateSeason;
 import com.github.thedeathlycow.thermoo.api.season.TropicalSeason;
+import com.github.thedeathlycow.thermoo.api.util.TemperatureRecord;
+import com.github.thedeathlycow.thermoo.impl.environment.attribute.TemperatureModifier;
 import net.minecraft.world.attribute.AttributeType;
 
 import java.util.Optional;
@@ -13,6 +15,12 @@ public final class ThermooAttributeTypes {
 
     public static final AttributeType<Optional<TropicalSeason>> TROPICAL_SEASON = AttributeType.ofNotInterpolated(
             TropicalSeason.CODEC.optionalFieldOf("value").codec()
+    );
+
+    public static final AttributeType<TemperatureRecord> TEMPERATURE = AttributeType.ofInterpolated(
+            TemperatureRecord.CODEC,
+            TemperatureModifier.TEMPERATURE_RECORD_LIBRARY,
+            TemperatureModifier::lerp
     );
 
     private ThermooAttributeTypes() {

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooAttributeTypes.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooAttributeTypes.java
@@ -2,27 +2,18 @@ package com.github.thedeathlycow.thermoo.api.environment.attribute;
 
 import com.github.thedeathlycow.thermoo.api.season.TemperateSeason;
 import com.github.thedeathlycow.thermoo.api.season.TropicalSeason;
-import com.github.thedeathlycow.thermoo.impl.Thermoo;
-import net.minecraft.core.Registry;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.attribute.AttributeType;
 
 import java.util.Optional;
 
 public final class ThermooAttributeTypes {
-    public static final AttributeType<Optional<TemperateSeason>> TEMPERATE_SEASON = register(
-            "temperate_season",
-            AttributeType.ofNotInterpolated(TemperateSeason.CODEC.optionalFieldOf("value").codec())
+    public static final AttributeType<Optional<TemperateSeason>> TEMPERATE_SEASON = AttributeType.ofNotInterpolated(
+            TemperateSeason.CODEC.optionalFieldOf("value").codec()
     );
 
-    public static final AttributeType<Optional<TropicalSeason>> TROPICAL_SEASON = register(
-            "tropical_season",
-            AttributeType.ofNotInterpolated(TropicalSeason.CODEC.optionalFieldOf("value").codec())
+    public static final AttributeType<Optional<TropicalSeason>> TROPICAL_SEASON = AttributeType.ofNotInterpolated(
+            TropicalSeason.CODEC.optionalFieldOf("value").codec()
     );
-
-    private static <V> AttributeType<V> register(String name, AttributeType<V> type) {
-        return Registry.register(BuiltInRegistries.ATTRIBUTE_TYPE, Thermoo.id(name), type);
-    }
 
     private ThermooAttributeTypes() {
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooEnvironmentAttributes.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooEnvironmentAttributes.java
@@ -1,0 +1,30 @@
+package com.github.thedeathlycow.thermoo.api.environment.attribute;
+
+import com.github.thedeathlycow.thermoo.api.season.TemperateSeason;
+import com.github.thedeathlycow.thermoo.api.season.TropicalSeason;
+import com.github.thedeathlycow.thermoo.impl.Thermoo;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.attribute.EnvironmentAttribute;
+
+import java.util.Optional;
+
+public final class ThermooEnvironmentAttributes {
+    public static final EnvironmentAttribute<Optional<TemperateSeason>> TEMPERATE_SEASON = register(
+            "gameplay/temperate_season",
+            EnvironmentAttribute.builder(ThermooAttributeTypes.TEMPERATE_SEASON)
+    );
+
+    public static final EnvironmentAttribute<Optional<TropicalSeason>> TROPICAL_SEASON = register(
+            "gameplay/tropical_season",
+            EnvironmentAttribute.builder(ThermooAttributeTypes.TROPICAL_SEASON)
+    );
+
+    private static <V> EnvironmentAttribute<V> register(String name, EnvironmentAttribute.Builder<V> builder) {
+        return Registry.register(BuiltInRegistries.ENVIRONMENT_ATTRIBUTE, Thermoo.id(name), builder.build());
+    }
+
+    private ThermooEnvironmentAttributes() {
+
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooEnvironmentAttributes.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooEnvironmentAttributes.java
@@ -2,6 +2,8 @@ package com.github.thedeathlycow.thermoo.api.environment.attribute;
 
 import com.github.thedeathlycow.thermoo.api.season.TemperateSeason;
 import com.github.thedeathlycow.thermoo.api.season.TropicalSeason;
+import com.github.thedeathlycow.thermoo.api.util.TemperatureRecord;
+import com.github.thedeathlycow.thermoo.api.util.TemperatureUnit;
 import net.minecraft.world.attribute.EnvironmentAttribute;
 
 import java.util.Optional;
@@ -13,6 +15,10 @@ public final class ThermooEnvironmentAttributes {
 
     public static final EnvironmentAttribute<Optional<TropicalSeason>> TROPICAL_SEASON = EnvironmentAttribute.builder(ThermooAttributeTypes.TROPICAL_SEASON)
             .defaultValue(Optional.empty())
+            .build();
+
+    public static final EnvironmentAttribute<TemperatureRecord> TEMPERATURE = EnvironmentAttribute.builder(ThermooAttributeTypes.TEMPERATURE)
+            .defaultValue(new TemperatureRecord(20, TemperatureUnit.CELSIUS))
             .build();
 
     private ThermooEnvironmentAttributes() {

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooEnvironmentAttributes.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooEnvironmentAttributes.java
@@ -8,15 +8,35 @@ import net.minecraft.world.attribute.EnvironmentAttribute;
 
 import java.util.Optional;
 
+/**
+ * Thermoo analogue for {@link net.minecraft.world.attribute.EnvironmentAttributes}.
+ * <p>
+ * Defines Thermoo's custom environment attributes.
+ */
 public final class ThermooEnvironmentAttributes {
+    /**
+     * An environment attribute that stores a temperate season. By default, this attribute is empty.
+     *
+     * @see ThermooAttributeTypes#TEMPERATE_SEASON
+     */
     public static final EnvironmentAttribute<Optional<TemperateSeason>> TEMPERATE_SEASON = EnvironmentAttribute.builder(ThermooAttributeTypes.TEMPERATE_SEASON)
             .defaultValue(Optional.empty())
             .build();
 
+    /**
+     * An environment attribute that stores a tropical season. By default, this attribute is empty.
+     *
+     * @see ThermooAttributeTypes#TROPICAL_SEASON
+     */
     public static final EnvironmentAttribute<Optional<TropicalSeason>> TROPICAL_SEASON = EnvironmentAttribute.builder(ThermooAttributeTypes.TROPICAL_SEASON)
             .defaultValue(Optional.empty())
             .build();
 
+    /**
+     * An environment attribute that stores a temperature record. This attribute defaults to 20°C.
+     *
+     * @see ThermooAttributeTypes#TEMPERATURE
+     */
     public static final EnvironmentAttribute<TemperatureRecord> TEMPERATURE = EnvironmentAttribute.builder(ThermooAttributeTypes.TEMPERATURE)
             .defaultValue(new TemperatureRecord(20, TemperatureUnit.CELSIUS))
             .build();

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooEnvironmentAttributes.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/ThermooEnvironmentAttributes.java
@@ -2,27 +2,18 @@ package com.github.thedeathlycow.thermoo.api.environment.attribute;
 
 import com.github.thedeathlycow.thermoo.api.season.TemperateSeason;
 import com.github.thedeathlycow.thermoo.api.season.TropicalSeason;
-import com.github.thedeathlycow.thermoo.impl.Thermoo;
-import net.minecraft.core.Registry;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.attribute.EnvironmentAttribute;
 
 import java.util.Optional;
 
 public final class ThermooEnvironmentAttributes {
-    public static final EnvironmentAttribute<Optional<TemperateSeason>> TEMPERATE_SEASON = register(
-            "gameplay/temperate_season",
-            EnvironmentAttribute.builder(ThermooAttributeTypes.TEMPERATE_SEASON)
-    );
+    public static final EnvironmentAttribute<Optional<TemperateSeason>> TEMPERATE_SEASON = EnvironmentAttribute.builder(ThermooAttributeTypes.TEMPERATE_SEASON)
+            .defaultValue(Optional.empty())
+            .build();
 
-    public static final EnvironmentAttribute<Optional<TropicalSeason>> TROPICAL_SEASON = register(
-            "gameplay/tropical_season",
-            EnvironmentAttribute.builder(ThermooAttributeTypes.TROPICAL_SEASON)
-    );
-
-    private static <V> EnvironmentAttribute<V> register(String name, EnvironmentAttribute.Builder<V> builder) {
-        return Registry.register(BuiltInRegistries.ENVIRONMENT_ATTRIBUTE, Thermoo.id(name), builder.build());
-    }
+    public static final EnvironmentAttribute<Optional<TropicalSeason>> TROPICAL_SEASON = EnvironmentAttribute.builder(ThermooAttributeTypes.TROPICAL_SEASON)
+            .defaultValue(Optional.empty())
+            .build();
 
     private ThermooEnvironmentAttributes() {
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/package-info.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/environment/attribute/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * API for Thermoo's custom environment attributes.
+ */
+package com.github.thedeathlycow.thermoo.api.environment.attribute;

--- a/src/main/java/com/github/thedeathlycow/thermoo/api/season/ThermooSeasonEvents.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/api/season/ThermooSeasonEvents.java
@@ -1,5 +1,6 @@
 package com.github.thedeathlycow.thermoo.api.season;
 
+import com.github.thedeathlycow.thermoo.api.environment.attribute.ThermooEnvironmentAttributes;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.core.BlockPos;
@@ -24,7 +25,8 @@ public final class ThermooSeasonEvents {
      * <p>
      * If any listener returns a non-empty season, then all further processing is cancelled and that season is returned.
      * <p>
-     * If the queried position does not have seasons, or a seasons mod is not installed, then returns empty.
+     * If the queried position does not have seasons, or a seasons mod is not installed, then returns the environment
+     * attribute value of {@link ThermooEnvironmentAttributes#TEMPERATE_SEASON}.
      * 
      * @see TemperateSeason#getCurrentSeason(Level, BlockPos)
      * @see #GET_CURRENT_TROPICAL_SEASON
@@ -39,7 +41,8 @@ public final class ThermooSeasonEvents {
                     }
                 }
 
-                return Optional.empty();
+                return level.environmentAttributes()
+                        .getValue(ThermooEnvironmentAttributes.TEMPERATE_SEASON, pos);
             }
     );
 
@@ -50,7 +53,8 @@ public final class ThermooSeasonEvents {
      * <p>
      * If any listener returns a non-empty season, then all further processing is cancelled and that season is returned.
      * <p>
-     * If the queried position is not tropical, or a seasons mod is not installed, then returns empty.
+     * If the queried position is not tropical, or a seasons mod is not installed, then returns the environment
+     * attribute value of {@link ThermooEnvironmentAttributes#TROPICAL_SEASON}.
      * 
      * @see TropicalSeason#getCurrentSeason(Level, BlockPos)
      * @see #GET_CURRENT_SEASON
@@ -65,7 +69,8 @@ public final class ThermooSeasonEvents {
                     }
                 }
 
-                return Optional.empty();
+                return level.environmentAttributes()
+                        .getValue(ThermooEnvironmentAttributes.TROPICAL_SEASON, pos);
             }
     );
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
@@ -82,6 +82,7 @@ public class Thermoo implements ModInitializer {
         ThermooCommonRegisters.registerTemperatureEffects();
         ThermooCommonRegisters.registerEnvironmentProviderTypes();
         ThermooCommonRegisters.registerLootConditionTypes();
+        ThermooCommonRegisters.registerEnvironmentAttributes();
 
         ResourceManagerHelper serverManager = ResourceManagerHelper.get(PackType.SERVER_DATA);
         serverManager.registerReloadListener(TemperatureEffectLoader.ID, TemperatureEffectLoader::new);

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/Thermoo.java
@@ -3,7 +3,10 @@ package com.github.thedeathlycow.thermoo.impl;
 import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
 import com.github.thedeathlycow.thermoo.api.command.*;
 import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
+import com.github.thedeathlycow.thermoo.api.environment.attribute.ThermooEnvironmentAttributes;
 import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProvider;
+import com.github.thedeathlycow.thermoo.api.season.TemperateSeason;
+import com.github.thedeathlycow.thermoo.api.season.ThermooSeasonEvents;
 import com.github.thedeathlycow.thermoo.impl.compat.init.DependentModInitializer;
 import com.github.thedeathlycow.thermoo.impl.config.ThermooConfig;
 import com.github.thedeathlycow.thermoo.impl.environment.EnvironmentLookupImpl;
@@ -25,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class Thermoo implements ModInitializer {
     public static final String MODID = "thermoo";

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooCommonRegisters.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooCommonRegisters.java
@@ -1,6 +1,8 @@
 package com.github.thedeathlycow.thermoo.impl;
 
 import com.github.thedeathlycow.thermoo.api.ThermooRegistries;
+import com.github.thedeathlycow.thermoo.api.environment.attribute.ThermooAttributeTypes;
+import com.github.thedeathlycow.thermoo.api.environment.attribute.ThermooEnvironmentAttributes;
 import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProviderType;
 import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProviderTypes;
 import com.github.thedeathlycow.thermoo.api.predicate.ThermooLootConditionTypes;
@@ -8,6 +10,8 @@ import com.github.thedeathlycow.thermoo.api.temperature.effects.TemperatureEffec
 import com.github.thedeathlycow.thermoo.api.temperature.effects.TemperatureEffects;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.attribute.AttributeType;
+import net.minecraft.world.attribute.EnvironmentAttribute;
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
 
 
@@ -43,6 +47,13 @@ public class ThermooCommonRegisters {
         registerLootConditionType("soaked", ThermooLootConditionTypes.SOAKED);
     }
 
+    public static void registerEnvironmentAttributes() {
+        registerAttributeType("temperate_season", ThermooAttributeTypes.TEMPERATE_SEASON);
+        registerAttributeType("tropical_season", ThermooAttributeTypes.TROPICAL_SEASON);
+        registerEnvironmentAttribute("gameplay/temperate_season", ThermooEnvironmentAttributes.TEMPERATE_SEASON);
+        registerEnvironmentAttribute("gameplay/tropical_season", ThermooEnvironmentAttributes.TROPICAL_SEASON);
+    }
+
     private static void registerTemperatureEffect(String name, TemperatureEffect<?> temperatureEffect) {
         Registry.register(ThermooRegistries.TEMPERATURE_EFFECTS, Thermoo.id(name), temperatureEffect);
     }
@@ -53,5 +64,13 @@ public class ThermooCommonRegisters {
 
     private static void registerLootConditionType(String name, LootItemConditionType lootConditionType) {
         Registry.register(BuiltInRegistries.LOOT_CONDITION_TYPE, Thermoo.id(name), lootConditionType);
+    }
+
+    private static <V> AttributeType<V> registerAttributeType(String name, AttributeType<V> type) {
+        return Registry.register(BuiltInRegistries.ATTRIBUTE_TYPE, Thermoo.id(name), type);
+    }
+
+    private static <V> EnvironmentAttribute<V> registerEnvironmentAttribute(String name, EnvironmentAttribute<V> attribute) {
+        return Registry.register(BuiltInRegistries.ENVIRONMENT_ATTRIBUTE, Thermoo.id(name), attribute);
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooCommonRegisters.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooCommonRegisters.java
@@ -50,8 +50,10 @@ public class ThermooCommonRegisters {
     public static void registerEnvironmentAttributes() {
         registerAttributeType("temperate_season", ThermooAttributeTypes.TEMPERATE_SEASON);
         registerAttributeType("tropical_season", ThermooAttributeTypes.TROPICAL_SEASON);
+        registerAttributeType("temperature", ThermooAttributeTypes.TEMPERATURE);
         registerEnvironmentAttribute("gameplay/temperate_season", ThermooEnvironmentAttributes.TEMPERATE_SEASON);
         registerEnvironmentAttribute("gameplay/tropical_season", ThermooEnvironmentAttributes.TROPICAL_SEASON);
+        registerEnvironmentAttribute("gameplay/temperature", ThermooEnvironmentAttributes.TEMPERATURE);
     }
 
     private static void registerTemperatureEffect(String name, TemperatureEffect<?> temperatureEffect) {

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/EnvironmentLookupImpl.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/EnvironmentLookupImpl.java
@@ -3,7 +3,10 @@ package com.github.thedeathlycow.thermoo.impl.environment;
 import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
 import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
 import com.github.thedeathlycow.thermoo.api.environment.EnvironmentLookup;
+import com.github.thedeathlycow.thermoo.api.environment.attribute.ThermooEnvironmentAttributes;
+import com.github.thedeathlycow.thermoo.api.environment.component.EnvironmentComponentTypes;
 import com.github.thedeathlycow.thermoo.api.environment.provider.EnvironmentProvider;
+import com.github.thedeathlycow.thermoo.api.util.TemperatureRecord;
 import com.github.thedeathlycow.thermoo.impl.Thermoo;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.minecraft.core.BlockPos;
@@ -12,6 +15,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.attribute.EnvironmentAttributeSystem;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -36,6 +40,11 @@ public class EnvironmentLookupImpl implements EnvironmentLookup {
 
     public DataComponentMap findEnvironmentComponentsForBiome(Level level, BlockPos pos, Holder<Biome> biome) {
         DataComponentMap.Builder builder = DataComponentMap.builder();
+
+        EnvironmentAttributeSystem attributes = level.environmentAttributes();
+        TemperatureRecord baseValue = attributes.getValue(ThermooEnvironmentAttributes.TEMPERATURE, pos);
+        builder.set(EnvironmentComponentTypes.TEMPERATURE, baseValue);
+
         for (Holder<EnvironmentProvider> provider : this.getProviders(biome)) {
             provider.value().buildCurrentComponents(level, pos, biome, builder);
         }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/attribute/TemperatureModifier.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/attribute/TemperatureModifier.java
@@ -1,0 +1,52 @@
+package com.github.thedeathlycow.thermoo.impl.environment.attribute;
+
+import com.github.thedeathlycow.thermoo.api.util.TemperatureRecord;
+import com.github.thedeathlycow.thermoo.api.util.TemperatureUnit;
+import com.mojang.serialization.Codec;
+import net.minecraft.util.Mth;
+import net.minecraft.world.attribute.EnvironmentAttribute;
+import net.minecraft.world.attribute.LerpFunction;
+import net.minecraft.world.attribute.modifier.AttributeModifier;
+
+import java.util.Map;
+
+public interface TemperatureModifier<Argument> extends AttributeModifier<TemperatureRecord, Argument> {
+    Simple ADD = TemperatureRecord::sum;
+    Simple SUBTRACT = (a, b) -> a.sum(new TemperatureRecord(-b.value(), b.unit()));
+    Simple MINIMUM = (a, b) -> a.compareTo(b) < 0 ? a : b;
+    Simple MAXIMUM = (a, b) -> a.compareTo(b) < 0 ? b : a;
+
+    Map<AttributeModifier.OperationId, AttributeModifier<TemperatureRecord, ?>> TEMPERATURE_RECORD_LIBRARY = Map.of(
+            AttributeModifier.OperationId.ADD,
+            ADD,
+            AttributeModifier.OperationId.SUBTRACT,
+            SUBTRACT,
+            AttributeModifier.OperationId.MINIMUM,
+            MINIMUM,
+            AttributeModifier.OperationId.MAXIMUM,
+            MAXIMUM
+    );
+
+    static TemperatureRecord lerp(float delta, TemperatureRecord a, TemperatureRecord b) {
+        double kelvinA = a.valueInUnit(TemperatureUnit.KELVIN);
+        double kelvinB = b.valueInUnit(TemperatureUnit.KELVIN);
+
+        double interpolated = Mth.lerp(delta, kelvinA, kelvinB);
+        var result = new TemperatureRecord(interpolated, TemperatureUnit.KELVIN);
+
+        return result.convertToUnit(a.unit());
+    }
+
+    @FunctionalInterface
+    interface Simple extends TemperatureModifier<TemperatureRecord> {
+        @Override
+        default Codec<TemperatureRecord> argumentCodec(EnvironmentAttribute<TemperatureRecord> attribute) {
+            return TemperatureRecord.CODEC;
+        }
+
+        @Override
+        default LerpFunction<TemperatureRecord> argumentKeyframeLerp(EnvironmentAttribute<TemperatureRecord> attribute) {
+            return TemperatureModifier::lerp;
+        }
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/attribute/package-info.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/attribute/package-info.java
@@ -1,0 +1,4 @@
+@ApiStatus.Internal
+package com.github.thedeathlycow.thermoo.impl.environment.attribute;
+
+import org.jetbrains.annotations.ApiStatus;

--- a/src/test/java/com/github/thedeathlycow/thermoo/impl/environment/attribute/TemperatureModifierTest.java
+++ b/src/test/java/com/github/thedeathlycow/thermoo/impl/environment/attribute/TemperatureModifierTest.java
@@ -1,0 +1,29 @@
+package com.github.thedeathlycow.thermoo.impl.environment.attribute;
+
+import com.github.thedeathlycow.thermoo.api.util.TemperatureRecord;
+import com.github.thedeathlycow.thermoo.api.util.TemperatureUnit;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TemperatureModifierTest {
+    @Test
+    void sub10Kfrom30K() {
+        var a = new TemperatureRecord(30, TemperatureUnit.KELVIN);
+        var b = new TemperatureRecord(10, TemperatureUnit.KELVIN);
+
+        var difference = TemperatureModifier.SUBTRACT.apply(a, b);
+
+        assertEquals(new TemperatureRecord(20, TemperatureUnit.KELVIN), difference);
+    }
+
+    @Test
+    void sub30Kfrom10K() {
+        var a = new TemperatureRecord(30, TemperatureUnit.KELVIN);
+        var b = new TemperatureRecord(10, TemperatureUnit.KELVIN);
+
+        var difference = TemperatureModifier.SUBTRACT.apply(b, a);
+
+        assertEquals(new TemperatureRecord(-20, TemperatureUnit.KELVIN), difference);
+    }
+}


### PR DESCRIPTION
Integrates the environment attribute system from 1.21.11 into Thermoo. Adds three new environment attributes: two for the different types of seasons, and one for temperature. These attributes are now used as the default values in the season events and environment component lookup functions. If the attributes are not specified, they will fallback to their normal default values (no season state and 20C).