### PR TITLE
Debug Screen Entries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,6 @@ maven_group=com.github.thedeathlycow
 archives_base_name=thermoo
 
 # Dependencies
-fabric_version=0.139.5+1.21.11
+fabric_version=0.141.3+1.21.11
 cca_version=7.3.0
 polymer_version=0.15.0-beta.4+1.21.11-rc2

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooClient.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooClient.java
@@ -4,11 +4,14 @@ import com.github.thedeathlycow.thermoo.impl.client.ThermooClientRegisters;
 import com.github.thedeathlycow.thermoo.impl.compat.ThermooPatchesNag;
 import com.github.thedeathlycow.thermoo.impl.compat.init.DependentClientModInitializer;
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.fabricmc.loader.api.FabricLoader;
 
 import java.util.Arrays;
 import java.util.List;
 
+@Environment(EnvType.CLIENT)
 public class ThermooClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooClient.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/ThermooClient.java
@@ -1,5 +1,6 @@
 package com.github.thedeathlycow.thermoo.impl;
 
+import com.github.thedeathlycow.thermoo.impl.client.ThermooClientRegisters;
 import com.github.thedeathlycow.thermoo.impl.compat.ThermooPatchesNag;
 import com.github.thedeathlycow.thermoo.impl.compat.init.DependentClientModInitializer;
 import net.fabricmc.api.ClientModInitializer;
@@ -13,6 +14,8 @@ public class ThermooClient implements ClientModInitializer {
     public void onInitializeClient() {
         ThermooPatchesNag.initialize(Thermoo.getConfig());
         initializeDependentEntryPoints();
+
+        ThermooClientRegisters.registerDebugEntries();
     }
 
     private static void initializeDependentEntryPoints() {

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/HeartBarContextImpl.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/HeartBarContextImpl.java
@@ -1,10 +1,13 @@
 package com.github.thedeathlycow.thermoo.impl.client;
 
 import com.github.thedeathlycow.thermoo.api.client.HeartBarContext;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import org.joml.Vector2i;
 
 import java.util.SequencedCollection;
 
+@Environment(EnvType.CLIENT)
 public record HeartBarContextImpl(
         SequencedCollection<Vector2i> positions,
         int currentDisplayHalfHearts,

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/ThermooClientRegisters.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/ThermooClientRegisters.java
@@ -4,8 +4,11 @@ import com.github.thedeathlycow.thermoo.impl.Thermoo;
 import com.github.thedeathlycow.thermoo.impl.client.debug.DebugEnvironmentComponents;
 import com.github.thedeathlycow.thermoo.impl.client.debug.DebugEnvironments;
 import com.github.thedeathlycow.thermoo.impl.client.debug.DebugSeasons;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.components.debug.DebugScreenEntries;
 
+@Environment(EnvType.CLIENT)
 public final class ThermooClientRegisters {
     public static void registerDebugEntries() {
         DebugScreenEntries.register(Thermoo.id("environment_components"), new DebugEnvironmentComponents());

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/ThermooClientRegisters.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/ThermooClientRegisters.java
@@ -1,0 +1,19 @@
+package com.github.thedeathlycow.thermoo.impl.client;
+
+import com.github.thedeathlycow.thermoo.impl.Thermoo;
+import com.github.thedeathlycow.thermoo.impl.client.debug.DebugEnvironmentComponents;
+import com.github.thedeathlycow.thermoo.impl.client.debug.DebugEnvironments;
+import com.github.thedeathlycow.thermoo.impl.client.debug.DebugSeasons;
+import net.minecraft.client.gui.components.debug.DebugScreenEntries;
+
+public final class ThermooClientRegisters {
+    public static void registerDebugEntries() {
+        DebugScreenEntries.register(Thermoo.id("environment_components"), new DebugEnvironmentComponents());
+        DebugScreenEntries.register(Thermoo.id("environments"), new DebugEnvironments());
+        DebugScreenEntries.register(Thermoo.id("seasons"), new DebugSeasons());
+    }
+
+    private ThermooClientRegisters() {
+
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugEnvironmentComponents.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugEnvironmentComponents.java
@@ -6,7 +6,6 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
-import net.minecraft.client.gui.components.debug.DebugScreenEntry;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.util.Util;
 import net.minecraft.world.entity.Entity;
@@ -17,7 +16,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.List;
 
 @Environment(EnvType.CLIENT)
-public class DebugEnvironmentComponents implements DebugScreenEntry {
+public class DebugEnvironmentComponents implements ThermooDebugScreenEntry {
     @Override
     public void display(DebugScreenDisplayer displayer, @Nullable Level level, @Nullable LevelChunk clientChunk, @Nullable LevelChunk serverChunk) {
         Minecraft minecraft = Minecraft.getInstance();
@@ -33,6 +32,7 @@ public class DebugEnvironmentComponents implements DebugScreenEntry {
                         return "%s: %s".formatted(name, component.value().toString());
                     }).toList();
 
+            displayer.addToGroup(DebugEnvironments.GROUP, "Environment components:");
             displayer.addToGroup(DebugEnvironments.GROUP, displayed);
         }
     }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugEnvironmentComponents.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugEnvironmentComponents.java
@@ -1,0 +1,39 @@
+package com.github.thedeathlycow.thermoo.impl.client.debug;
+
+import com.github.thedeathlycow.thermoo.api.ThermooRegistries;
+import com.github.thedeathlycow.thermoo.api.environment.EnvironmentLookup;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
+import net.minecraft.client.gui.components.debug.DebugScreenEntry;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.util.Util;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+@Environment(EnvType.CLIENT)
+public class DebugEnvironmentComponents implements DebugScreenEntry {
+    @Override
+    public void display(DebugScreenDisplayer displayer, @Nullable Level level, @Nullable LevelChunk clientChunk, @Nullable LevelChunk serverChunk) {
+        Minecraft minecraft = Minecraft.getInstance();
+        @Nullable Entity cameraEntity = minecraft.getCameraEntity();
+
+        if (cameraEntity != null) {
+            DataComponentMap components = EnvironmentLookup.getInstance()
+                    .findEnvironmentComponents(level, cameraEntity.blockPosition());
+
+            List<String> displayed = components.stream()
+                    .map(component -> {
+                        String name = Util.getRegisteredName(ThermooRegistries.ENVIRONMENT_COMPONENT_TYPE, component.type());
+                        return "%s: %s".formatted(name, component.value().toString());
+                    }).toList();
+
+            displayer.addToGroup(DebugEnvironments.GROUP, displayed);
+        }
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugEnvironments.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugEnvironments.java
@@ -1,0 +1,49 @@
+package com.github.thedeathlycow.thermoo.impl.client.debug;
+
+import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
+import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
+import com.github.thedeathlycow.thermoo.impl.Thermoo;
+import com.github.thedeathlycow.thermoo.impl.environment.EnvironmentLookupImpl;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
+import net.minecraft.client.gui.components.debug.DebugScreenEntry;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.Util;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class DebugEnvironments implements DebugScreenEntry {
+    public static final Identifier GROUP = Thermoo.id("thermoo");
+
+    @Override
+    public void display(DebugScreenDisplayer displayer, @Nullable Level level, @Nullable LevelChunk clientChunk, @Nullable LevelChunk serverChunk) {
+        Minecraft minecraft = Minecraft.getInstance();
+        @Nullable Entity cameraEntity = minecraft.getCameraEntity();
+
+        if (cameraEntity != null && level instanceof ServerLevel serverLevel) {
+            Registry<EnvironmentDefinition> registry = serverLevel
+                    .registryAccess()
+                    .lookupOrThrow(ThermooRegistryKeys.ENVIRONMENT);
+
+            Stream<EnvironmentDefinition> environments = EnvironmentLookupImpl.getAllMatchingEnvironments(
+                    level.getBiome(cameraEntity.blockPosition()),
+                    registry
+            );
+
+
+            displayer.addToGroup(GROUP, "Environments available:");
+
+            List<String> displayed = environments.map(environment -> {
+                return "%s".formatted(Util.getRegisteredName(registry, environment));
+            }).toList();
+            displayer.addToGroup(GROUP, displayed);
+        }
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugEnvironments.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugEnvironments.java
@@ -4,6 +4,8 @@ import com.github.thedeathlycow.thermoo.api.ThermooRegistryKeys;
 import com.github.thedeathlycow.thermoo.api.environment.EnvironmentDefinition;
 import com.github.thedeathlycow.thermoo.impl.Thermoo;
 import com.github.thedeathlycow.thermoo.impl.environment.EnvironmentLookupImpl;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
 import net.minecraft.core.Registry;
@@ -18,6 +20,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.stream.Stream;
 
+@Environment(EnvType.CLIENT)
 public class DebugEnvironments implements ThermooDebugScreenEntry {
     public static final Identifier GROUP = Thermoo.id("thermoo");
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugEnvironments.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugEnvironments.java
@@ -6,7 +6,6 @@ import com.github.thedeathlycow.thermoo.impl.Thermoo;
 import com.github.thedeathlycow.thermoo.impl.environment.EnvironmentLookupImpl;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
-import net.minecraft.client.gui.components.debug.DebugScreenEntry;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerLevel;
@@ -19,7 +18,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.stream.Stream;
 
-public class DebugEnvironments implements DebugScreenEntry {
+public class DebugEnvironments implements ThermooDebugScreenEntry {
     public static final Identifier GROUP = Thermoo.id("thermoo");
 
     @Override

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugSeasons.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugSeasons.java
@@ -6,7 +6,6 @@ import com.github.thedeathlycow.thermoo.api.season.ThermooSeasonState;
 import com.github.thedeathlycow.thermoo.api.season.TropicalSeason;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
-import net.minecraft.client.gui.components.debug.DebugScreenEntry;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -14,7 +13,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.Optional;
 
-public class DebugSeasons implements DebugScreenEntry {
+public class DebugSeasons implements ThermooDebugScreenEntry {
     @Override
     public void display(DebugScreenDisplayer displayer, @Nullable Level level, @Nullable LevelChunk clientChunk, @Nullable LevelChunk serverChunk) {
         Minecraft minecraft = Minecraft.getInstance();

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugSeasons.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugSeasons.java
@@ -4,6 +4,8 @@ import com.github.thedeathlycow.thermoo.api.season.TemperateSeason;
 import com.github.thedeathlycow.thermoo.api.season.ThermooSeason;
 import com.github.thedeathlycow.thermoo.api.season.ThermooSeasonState;
 import com.github.thedeathlycow.thermoo.api.season.TropicalSeason;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
 import net.minecraft.world.entity.Entity;
@@ -13,6 +15,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.Optional;
 
+@Environment(EnvType.CLIENT)
 public class DebugSeasons implements ThermooDebugScreenEntry {
     @Override
     public void display(DebugScreenDisplayer displayer, @Nullable Level level, @Nullable LevelChunk clientChunk, @Nullable LevelChunk serverChunk) {

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugSeasons.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/DebugSeasons.java
@@ -1,0 +1,40 @@
+package com.github.thedeathlycow.thermoo.impl.client.debug;
+
+import com.github.thedeathlycow.thermoo.api.season.TemperateSeason;
+import com.github.thedeathlycow.thermoo.api.season.ThermooSeason;
+import com.github.thedeathlycow.thermoo.api.season.ThermooSeasonState;
+import com.github.thedeathlycow.thermoo.api.season.TropicalSeason;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
+import net.minecraft.client.gui.components.debug.DebugScreenEntry;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+
+public class DebugSeasons implements DebugScreenEntry {
+    @Override
+    public void display(DebugScreenDisplayer displayer, @Nullable Level level, @Nullable LevelChunk clientChunk, @Nullable LevelChunk serverChunk) {
+        Minecraft minecraft = Minecraft.getInstance();
+        @Nullable Entity cameraEntity = minecraft.getCameraEntity();
+
+        if (level != null && cameraEntity != null) {
+            Optional<ThermooSeasonState<TemperateSeason>> temperateSeason = TemperateSeason.getCurrentState(level, cameraEntity.blockPosition());
+            Optional<ThermooSeasonState<TropicalSeason>> tropicalSeason = TropicalSeason.getCurrentState(level, cameraEntity.blockPosition());
+
+            this.addLine(displayer, "Temperate Season", temperateSeason);
+            this.addLine(displayer, "Tropical Season", tropicalSeason);
+        }
+    }
+
+    private <S extends ThermooSeason> void addLine(DebugScreenDisplayer displayer, String name, Optional<ThermooSeasonState<S>> result) {
+        if (result.isPresent()) {
+            ThermooSeasonState<?> state = result.get();
+            displayer.addToGroup(DebugEnvironments.GROUP, "%s: %s (%s%%)".formatted(name, state.season().getSerializedName(), state.progress() * 100));
+        } else {
+            displayer.addToGroup(DebugEnvironments.GROUP, "%s: [None]".formatted(name));
+        }
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/ThermooDebugScreenEntry.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/ThermooDebugScreenEntry.java
@@ -10,6 +10,7 @@ import net.minecraft.network.chat.Component;
 public interface ThermooDebugScreenEntry extends DebugScreenEntry {
     DebugEntryCategory CATEGORY = new DebugEntryCategory(Component.translatable("debug.options.category.thermoo"), 3.0f);
 
+    @Override
     default DebugEntryCategory category() {
         return CATEGORY;
     }

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/ThermooDebugScreenEntry.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/ThermooDebugScreenEntry.java
@@ -1,9 +1,12 @@
 package com.github.thedeathlycow.thermoo.impl.client.debug;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.components.debug.DebugEntryCategory;
 import net.minecraft.client.gui.components.debug.DebugScreenEntry;
 import net.minecraft.network.chat.Component;
 
+@Environment(EnvType.CLIENT)
 public interface ThermooDebugScreenEntry extends DebugScreenEntry {
     DebugEntryCategory CATEGORY = new DebugEntryCategory(Component.translatable("debug.options.category.thermoo"), 3.0f);
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/ThermooDebugScreenEntry.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/client/debug/ThermooDebugScreenEntry.java
@@ -1,0 +1,13 @@
+package com.github.thedeathlycow.thermoo.impl.client.debug;
+
+import net.minecraft.client.gui.components.debug.DebugEntryCategory;
+import net.minecraft.client.gui.components.debug.DebugScreenEntry;
+import net.minecraft.network.chat.Component;
+
+public interface ThermooDebugScreenEntry extends DebugScreenEntry {
+    DebugEntryCategory CATEGORY = new DebugEntryCategory(Component.translatable("debug.options.category.thermoo"), 3.0f);
+
+    default DebugEntryCategory category() {
+        return CATEGORY;
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/EnvironmentLookupImpl.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/impl/environment/EnvironmentLookupImpl.java
@@ -76,7 +76,6 @@ public class EnvironmentLookupImpl implements EnvironmentLookup {
         });
     }
 
-    @VisibleForTesting
     public static Stream<EnvironmentDefinition> getAllMatchingEnvironments(Holder<Biome> biome, Registry<EnvironmentDefinition> envRegistry) {
         return envRegistry.stream()
                 .filter(entry -> entry.providesFor(biome))

--- a/src/main/resources/assets/thermoo/lang/en_us.json
+++ b/src/main/resources/assets/thermoo/lang/en_us.json
@@ -49,5 +49,7 @@
     "text.thermoo.thermoo-patches-nag.body": "The following mod(s) can work with Thermoo, Frostiful, and/or Scorchful, but you are missing the Thermoo Patches compatibility mod:",
     "text.thermoo.thermoo-patches-nag.item": "- %1$s (%2$s)",
     "text.thermoo.thermoo-patches-nag.footer": "You can get Thermoo Patches at the below link:",
-    "text.thermoo.thermoo-patches-nag.disable": "You may disable this message at any time in the Thermoo config."
+    "text.thermoo.thermoo-patches-nag.disable": "You may disable this message at any time in the Thermoo config.",
+    
+    "debug.options.category.thermoo": "Thermoo Screen Text"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -41,7 +41,7 @@
     ],
     "depends": {
         "fabricloader": ">=0.17.2",
-        "fabric-api": ">=0.139.5",
+        "fabric-api": ">=0.141.3",
         "minecraft": ">=1.21.11",
         "java": ">=21",
         "cardinal-components-base": ">=7.3.0",


### PR DESCRIPTION
Improve my quality of life my adding some custom debug screen entries for environment components, available environments (singleplayer only!), and seasons. These are not shown in the overlay by default. 